### PR TITLE
Enable you to use expressions instead of manually entering the property name

### DIFF
--- a/src/Projects/EnsureThat/Ensure.cs
+++ b/src/Projects/EnsureThat/Ensure.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 using System.Linq.Expressions;
 
 namespace EnsureThat

--- a/src/Projects/EnsureThat/Ensure.cs
+++ b/src/Projects/EnsureThat/Ensure.cs
@@ -1,3 +1,7 @@
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+
 namespace EnsureThat
 {
     public static class Ensure
@@ -5,6 +9,17 @@ namespace EnsureThat
         public static Param<T> That<T>(T value, string name = Param.DefaultName)
         {
             return new Param<T>(name, value);
+        }
+
+        public static Param<T> That<T>(Expression<Func<object, T>> expression, string name = Param.DefaultName)
+        {
+            if (name == Param.DefaultName)
+            {
+                var memberExpressionBody = (MemberExpression)expression.Body;
+                name = memberExpressionBody.Member.Name;
+            }
+
+            return new Param<T>(name, expression.Compile().Invoke(null));
         }
 
         public static TypeParam ThatTypeFor<T>(T value, string name = Param.DefaultName)


### PR DESCRIPTION
Instead of having to write `Ensure.That(userName, "userName).IsNotNullOrWhitespace()` you can now write `Ensure.That(x => userName).IsNotNullOrWhiteSpace()` this will infer the correct type and output the representation for that name.

Hence if there is a problem with the above it will output: `Parameter name: userName`

I haven't added or updated any tests yet, but it's been working good as far as I've tested manually :+1: 
