### PR TITLE
Ensure.That.Source should be a development dependency

### DIFF
--- a/deploy/Ensure.That.Source.nuspec
+++ b/deploy/Ensure.That.Source.nuspec
@@ -17,6 +17,7 @@
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <releaseNotes>https://github.com/danielwertheim/Ensure.That/wiki/Release-notes</releaseNotes>
         <tags>argument validation guard clause</tags>
+        <developmentDependency>true</developmentDependency>
     </metadata>
     <files>
         <file src="Projects\EnsureThat.Shared\**\*.cs" target="Content\EnsureThat" exclude="Projects\EnsureThat\Properties\**\*.cs" />


### PR DESCRIPTION
Ensure.That.Source should be a development dependency to prevent it from being dragged into related packages.
