### PR TITLE
NoEnumeration attribute for EnsureArg.IsNotNull

### DIFF
--- a/src/projects/EnsureThat/EnsureArg.Objects.cs
+++ b/src/projects/EnsureThat/EnsureArg.Objects.cs
@@ -1,12 +1,13 @@
 ﻿using System;
 using System.Diagnostics;
+using JetBrains.Annotations;
 
 namespace EnsureThat
 {
     public static partial class EnsureArg
     {
         [DebuggerStepThrough]
-        public static void IsNotNull<T>(T value, string paramName = Param.DefaultName) where T : class
+        public static void IsNotNull<T>([NoEnumeration] T value, string paramName = Param.DefaultName) where T : class
         {
             if (!Ensure.IsActive)
                 return;


### PR DESCRIPTION
Added NoEnumeration attribute to EnsureArg.IsNotNull so R# doesn't complain about multiple enumeration.