### PR TITLE
Add overload for WithExtraMessageOf to accept strings

### DIFF
--- a/src/projects/EnsureThat/ParamExtensions.cs
+++ b/src/projects/EnsureThat/ParamExtensions.cs
@@ -9,6 +9,13 @@ namespace EnsureThat
             return param;
         }
 
+        public static Param<T> WithExtraMessageOf<T>(this Param<T> param, string message)
+        {
+            param.ExtraMessageFn = p => message;
+
+            return param;
+        }
+
         public static Param<T> WithExtraMessageOf<T>(this Param<T> param, Func<string> messageFn)
         {
             param.ExtraMessageFn = p => messageFn();

--- a/src/tests/UnitTests/WithExtraMessageOfTests.cs
+++ b/src/tests/UnitTests/WithExtraMessageOfTests.cs
@@ -19,5 +19,19 @@ namespace UnitTests
             AssertThrowedAsExpected(ex, ExceptionMessages.Common_IsNotNull_Failed
                 + "\r\nFoo bar is some dummy text.");
         }
+
+        [Fact]
+        public void WithExtraMessageOf_WhenSpecifyingExtraMessageAsSimpleString_ItGetsAppendedOnTheEnd()
+        {
+            object value = null;
+
+            // ReSharper disable once ExpressionIsAlwaysNull
+            var ex = Assert.Throws<ArgumentNullException>(() => Ensure.That(value, ParamName)
+                .WithExtraMessageOf("Foo bar is some dummy text.")
+                .IsNotNull());
+
+            AssertThrowedAsExpected(ex, ExceptionMessages.Common_IsNotNull_Failed
+                                        + "\r\nFoo bar is some dummy text.");
+        }
     }
 }


### PR DESCRIPTION
Adds an overload for `WithExtraMessageOf` that accepts simple strings, rather than functions returning strings.

Just started using Ensure.That - it seems nice, but I'd like to just pass strings directly to `WithExtraMessageOf`. I assume that the reason it takes functions returning strings is for performance, but in many cases I don't think it would make a lot of difference, and it slightly reduces bloat to omit the `() =>` before the string.
