### PR TITLE
made project multi-targetted, usable in net452, net462, net47, netstandard1.1 and 2.0

### DIFF
--- a/src/projects/EnsureThat/EnsureThat.csproj
+++ b/src/projects/EnsureThat/EnsureThat.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.1</TargetFramework>
+    <TargetFrameworks>netstandard1.1;netstandard2.0;net452;net462;net47</TargetFrameworks>
     <Version>0.0.0</Version>
     <Authors>danielwertheim</Authors>
     <Company>danielwertheim</Company>


### PR DESCRIPTION
I use Ensure.That a lot and now want to use it in a project that targets SharePoint 2013, hence the net452/net462 option. The change in minimal, and all tests still run 