### PR TITLE
Introduce some overloads IEquatable

### DIFF
--- a/src/projects/EnsureThat/ComparableArg.cs
+++ b/src/projects/EnsureThat/ComparableArg.cs
@@ -7,6 +7,7 @@ namespace EnsureThat
     public class ComparableArg
     {
         [DebuggerStepThrough]
+        [Obsolete("Prefer EquatableArg.IsNot where possible")]
         public T Is<T>(T value, T expected, string paramName = Param.DefaultName) where T : IComparable<T>
         {
             if (!Ensure.IsActive)
@@ -19,6 +20,7 @@ namespace EnsureThat
         }
 
         [DebuggerStepThrough]
+        [Obsolete("Prefer EquatableArg.IsNot where possible")]
         public T IsNot<T>(T value, T expected, string paramName = Param.DefaultName) where T : IComparable<T>
         {
             if (!Ensure.IsActive)

--- a/src/projects/EnsureThat/ComparableArg.cs
+++ b/src/projects/EnsureThat/ComparableArg.cs
@@ -7,7 +7,7 @@ namespace EnsureThat
     public class ComparableArg
     {
         [DebuggerStepThrough]
-        [Obsolete("Prefer EquatableArg.IsNot where possible")]
+        [Obsolete("Prefer EquatableArg.Is where possible")]
         public T Is<T>(T value, T expected, string paramName = Param.DefaultName) where T : IComparable<T>
         {
             if (!Ensure.IsActive)

--- a/src/projects/EnsureThat/ComparableArg.cs
+++ b/src/projects/EnsureThat/ComparableArg.cs
@@ -10,7 +10,7 @@ namespace EnsureThat
     {
         [NotNull]
         [DebuggerStepThrough]
-        [Obsolete("Prefer EquatableArg.Is where possible")]
+        [Obsolete("Prefer EquatableArg.Equals where possible")]
         public T Is<T>([NotNull] T value, T expected, [InvokerParameterName] string paramName = Param.DefaultName) where T : IComparable<T>
         {
             if (!Ensure.IsActive)
@@ -23,7 +23,7 @@ namespace EnsureThat
         }
 
         [DebuggerStepThrough]
-        [Obsolete("Prefer EquatableArg.Is where possible")]
+        [Obsolete("Prefer EquatableArg.Equals where possible")]
         public T Is<T>(T value, T expected, [NotNull] IComparer<T> comparer, [InvokerParameterName] string paramName = Param.DefaultName)
         {
             if (!Ensure.IsActive)
@@ -37,7 +37,7 @@ namespace EnsureThat
 
         [NotNull]
         [DebuggerStepThrough]
-        [Obsolete("Prefer EquatableArg.IsNot where possible")]
+        [Obsolete("Prefer EquatableArg.DoesNotEqual where possible")]
         public T IsNot<T>([NotNull] T value, T expected, [InvokerParameterName] string paramName = Param.DefaultName) where T : IComparable<T>
         {
             if (!Ensure.IsActive)
@@ -50,7 +50,7 @@ namespace EnsureThat
         }
 
         [DebuggerStepThrough]
-        [Obsolete("Prefer EquatableArg.IsNot where possible")]
+        [Obsolete("Prefer EquatableArg.DoesNotEqual where possible")]
         public T IsNot<T>(T value, T expected, [NotNull] IComparer<T> comparer, [InvokerParameterName] string paramName = Param.DefaultName)
         {
             if (!Ensure.IsActive)

--- a/src/projects/EnsureThat/Ensure.cs
+++ b/src/projects/EnsureThat/Ensure.cs
@@ -20,6 +20,8 @@ namespace EnsureThat
 
         public static ComparableArg Comparable { get; } = new ComparableArg();
 
+        public static EquatableArg Equatable { get; } = new EquatableArg();
+
         public static GuidArg Guid { get; } = new GuidArg();
 
         public static StringArg String { get; } = new StringArg();

--- a/src/projects/EnsureThat/EnsureArg.Comparables.cs
+++ b/src/projects/EnsureThat/EnsureArg.Comparables.cs
@@ -9,21 +9,21 @@ namespace EnsureThat
     {
         [NotNull]
         [DebuggerStepThrough]
-        public static T Is<T>([NotNull] T value, T expected, [InvokerParameterName] string paramName = Param.DefaultName) where T : IEquatable<T>
-            => Ensure.Equatable.Is(value, expected, paramName);
+        public static T Is<T>([NotNull] T value, T expected, [InvokerParameterName] string paramName = Param.DefaultName) where T : IComparable<T>
+            => Ensure.Comparable.Is(value, expected, paramName);
 
         [DebuggerStepThrough]
-        public static T Is<T>(T value, T expected, [NotNull] IEqualityComparer<T> comparer, [InvokerParameterName] string paramName = Param.DefaultName)
-            => Ensure.Equatable.Is(value, expected, comparer, paramName);
+        public static T Is<T>(T value, T expected, [NotNull] IComparer<T> comparer, [InvokerParameterName] string paramName = Param.DefaultName)
+            => Ensure.Comparable.Is(value, expected, comparer, paramName);
 
         [NotNull]
         [DebuggerStepThrough]
-        public static T IsNot<T>([NotNull] T value, T expected, [InvokerParameterName] string paramName = Param.DefaultName) where T : IEquatable<T>
-            => Ensure.Equatable.IsNot(value, expected, paramName);
+        public static T IsNot<T>([NotNull] T value, T expected, [InvokerParameterName] string paramName = Param.DefaultName) where T : IComparable<T>
+            => Ensure.Comparable.IsNot(value, expected, paramName);
 
         [DebuggerStepThrough]
-        public static T IsNot<T>(T value, T expected, [NotNull] IEqualityComparer<T> comparer, [InvokerParameterName] string paramName = Param.DefaultName)
-            => Ensure.Equatable.IsNot(value, expected, comparer, paramName);
+        public static T IsNot<T>(T value, T expected, [NotNull] IComparer<T> comparer, [InvokerParameterName] string paramName = Param.DefaultName)
+            => Ensure.Comparable.IsNot(value, expected, comparer, paramName);
 
         [NotNull]
         [DebuggerStepThrough]

--- a/src/projects/EnsureThat/EnsureArg.Comparables.cs
+++ b/src/projects/EnsureThat/EnsureArg.Comparables.cs
@@ -6,12 +6,12 @@ namespace EnsureThat
     public static partial class EnsureArg
     {
         [DebuggerStepThrough]
-        public static T Is<T>(T value, T expected, string paramName = Param.DefaultName) where T : IComparable<T>
-            => Ensure.Comparable.Is(value, expected, paramName);
+        public static T Is<T>(T value, T expected, string paramName = Param.DefaultName) where T : IEquatable<T>
+            => Ensure.Equatable.Is(value, expected, paramName);
 
         [DebuggerStepThrough]
-        public static T IsNot<T>(T value, T expected, string paramName = Param.DefaultName) where T : IComparable<T>
-            => Ensure.Comparable.IsNot(value, expected, paramName);
+        public static T IsNot<T>(T value, T expected, string paramName = Param.DefaultName) where T : IEquatable<T>
+            => Ensure.Equatable.IsNot(value, expected, paramName);
 
         [DebuggerStepThrough]
         public static T IsLt<T>(T value, T limit, string paramName = Param.DefaultName) where T : IComparable<T>

--- a/src/projects/EnsureThat/EnsureArg.Equatables.cs
+++ b/src/projects/EnsureThat/EnsureArg.Equatables.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using JetBrains.Annotations;
+
+namespace EnsureThat
+{
+    public static partial class EnsureArg
+    {
+        [NotNull]
+        [DebuggerStepThrough]
+        public static T Equals<T>([NotNull] T value, T expected, [InvokerParameterName] string paramName = Param.DefaultName) where T : IEquatable<T>
+            => Ensure.Equatable.Equals(value, expected, paramName);
+
+        [DebuggerStepThrough]
+        public static T Equals<T>(T value, T expected, [NotNull] IEqualityComparer<T> comparer, [InvokerParameterName] string paramName = Param.DefaultName)
+            => Ensure.Equatable.Equals(value, expected, comparer, paramName);
+
+        [NotNull]
+        [DebuggerStepThrough]
+        public static T DoesNotEqual<T>([NotNull] T value, T expected, [InvokerParameterName] string paramName = Param.DefaultName) where T : IEquatable<T>
+            => Ensure.Equatable.DoesNotEqual(value, expected, paramName);
+
+        [DebuggerStepThrough]
+        public static T DoesNotEqual<T>(T value, T expected, [NotNull] IEqualityComparer<T> comparer, [InvokerParameterName] string paramName = Param.DefaultName)
+            => Ensure.Equatable.DoesNotEqual(value, expected, comparer, paramName);
+    }
+}

--- a/src/projects/EnsureThat/EnsureComparableExtensions.cs
+++ b/src/projects/EnsureThat/EnsureComparableExtensions.cs
@@ -7,7 +7,7 @@ namespace EnsureThat
     public static class EnsureComparableExtensions
     {
         [DebuggerStepThrough]
-        public static void Is<T>(this Param<T> param, T expected) where T : IComparable<T>
+        public static void Is<T>(this Param<T> param, T expected) where T : IEquatable<T>
         {
             if (!Ensure.IsActive)
                 return;
@@ -17,7 +17,7 @@ namespace EnsureThat
         }
 
         [DebuggerStepThrough]
-        public static void IsNot<T>(this Param<T> param, T expected) where T : IComparable<T>
+        public static void IsNot<T>(this Param<T> param, T expected) where T : IEquatable<T>
         {
             if (!Ensure.IsActive)
                 return;

--- a/src/projects/EnsureThat/EnsureComparableExtensions.cs
+++ b/src/projects/EnsureThat/EnsureComparableExtensions.cs
@@ -8,7 +8,8 @@ namespace EnsureThat
     public static class EnsureComparableExtensions
     {
         [DebuggerStepThrough]
-        public static void Is<T>(this Param<T> param, T expected) where T : IEquatable<T>
+        [Obsolete("Prefer Equals where possible")]
+        public static void Is<T>(this Param<T> param, T expected) where T : IComparable<T>
         {
             if (!Ensure.IsActive)
                 return;
@@ -18,7 +19,8 @@ namespace EnsureThat
         }
 
         [DebuggerStepThrough]
-        public static void Is<T>(this Param<T> param, T expected, IEqualityComparer<T> comparer)
+        [Obsolete("Prefer Equals where possible")]
+        public static void Is<T>(this Param<T> param, T expected, IComparer<T> comparer)
         {
             if (!Ensure.IsActive)
                 return;
@@ -28,7 +30,8 @@ namespace EnsureThat
         }
 
         [DebuggerStepThrough]
-        public static void IsNot<T>(this Param<T> param, T expected) where T : IEquatable<T>
+        [Obsolete("Prefer DoesNotEquals where possible")]
+        public static void IsNot<T>(this Param<T> param, T expected) where T : IComparable<T>
         {
             if (!Ensure.IsActive)
                 return;
@@ -38,7 +41,8 @@ namespace EnsureThat
         }
 
         [DebuggerStepThrough]
-        public static void IsNot<T>(this Param<T> param, T expected, IEqualityComparer<T> comparer)
+        [Obsolete("Prefer DoesNotEquals where possible")]
+        public static void IsNot<T>(this Param<T> param, T expected, IComparer<T> comparer)
         {
             if (!Ensure.IsActive)
                 return;

--- a/src/projects/EnsureThat/EnsureEquatableExtensions.cs
+++ b/src/projects/EnsureThat/EnsureEquatableExtensions.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using EnsureThat.Extensions;
+
+namespace EnsureThat
+{
+    public static class EnsureEquatableExtensions
+    {
+        [DebuggerStepThrough]
+        public static void Equals<T>(this Param<T> param, T expected) where T : IEquatable<T>
+        {
+            if (!Ensure.IsActive)
+                return;
+
+            if (!param.Value.IsEq(expected))
+                throw ExceptionFactory.CreateForParamValidation(param, ExceptionMessages.Comp_Is_Failed.Inject(param.Value, expected));
+        }
+
+        [DebuggerStepThrough]
+        public static void Equals<T>(this Param<T> param, T expected, IEqualityComparer<T> comparer)
+        {
+            if (!Ensure.IsActive)
+                return;
+
+            if (!param.Value.IsEq(expected, comparer))
+                throw ExceptionFactory.CreateForParamValidation(param, ExceptionMessages.Comp_Is_Failed.Inject(param.Value, expected));
+        }
+
+        [DebuggerStepThrough]
+        public static void DoesNotEqual<T>(this Param<T> param, T expected) where T : IEquatable<T>
+        {
+            if (!Ensure.IsActive)
+                return;
+
+            if (param.Value.IsEq(expected))
+                throw ExceptionFactory.CreateForParamValidation(param, ExceptionMessages.Comp_IsNot_Failed.Inject(param.Value, expected));
+        }
+
+        [DebuggerStepThrough]
+        public static void DoesNotEqual<T>(this Param<T> param, T expected, IEqualityComparer<T> comparer)
+        {
+            if (!Ensure.IsActive)
+                return;
+
+            if (param.Value.IsEq(expected, comparer))
+                throw ExceptionFactory.CreateForParamValidation(param, ExceptionMessages.Comp_IsNot_Failed.Inject(param.Value, expected));
+        }
+    }
+}

--- a/src/projects/EnsureThat/EquatableArg.cs
+++ b/src/projects/EnsureThat/EquatableArg.cs
@@ -1,13 +1,16 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using EnsureThat.Extensions;
+using JetBrains.Annotations;
 
 namespace EnsureThat
 {
     public class EquatableArg
     {
+        [NotNull]
         [DebuggerStepThrough]
-        public T Is<T>(T value, T expected, string paramName = Param.DefaultName) where T : IEquatable<T>
+        public T Equals<T>([NotNull] T value, T expected, [InvokerParameterName] string paramName = Param.DefaultName) where T : IEquatable<T>
         {
             if (!Ensure.IsActive)
                 return value;
@@ -19,12 +22,37 @@ namespace EnsureThat
         }
 
         [DebuggerStepThrough]
-        public T IsNot<T>(T value, T expected, string paramName = Param.DefaultName) where T : IEquatable<T>
+        public T Equals<T>(T value, T expected, [NotNull] IEqualityComparer<T> comparer, [InvokerParameterName] string paramName = Param.DefaultName)
+        {
+            if (!Ensure.IsActive)
+                return value;
+
+            if (!value.IsEq(expected, comparer))
+                throw new ArgumentException(ExceptionMessages.Comp_Is_Failed.Inject(value, expected), paramName);
+
+            return value;
+        }
+
+        [NotNull]
+        [DebuggerStepThrough]
+        public T DoesNotEqual<T>([NotNull] T value, T expected, [InvokerParameterName] string paramName = Param.DefaultName) where T : IEquatable<T>
         {
             if (!Ensure.IsActive)
                 return value;
 
             if (value.IsEq(expected))
+                throw new ArgumentException(ExceptionMessages.Comp_IsNot_Failed.Inject(value, expected), paramName);
+
+            return value;
+        }
+
+        [DebuggerStepThrough]
+        public T DoesNotEqual<T>(T value, T expected, [NotNull] IEqualityComparer<T> comparer, [InvokerParameterName] string paramName = Param.DefaultName)
+        {
+            if (!Ensure.IsActive)
+                return value;
+
+            if (value.IsEq(expected, comparer))
                 throw new ArgumentException(ExceptionMessages.Comp_IsNot_Failed.Inject(value, expected), paramName);
 
             return value;

--- a/src/projects/EnsureThat/EquatableArg.cs
+++ b/src/projects/EnsureThat/EquatableArg.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Diagnostics;
+using EnsureThat.Extensions;
+
+namespace EnsureThat
+{
+    public class EquatableArg
+    {
+        [DebuggerStepThrough]
+        public T Is<T>(T value, T expected, string paramName = Param.DefaultName) where T : IEquatable<T>
+        {
+            if (!Ensure.IsActive)
+                return value;
+
+            if (!value.IsEq(expected))
+                throw new ArgumentException(ExceptionMessages.Comp_Is_Failed.Inject(value, expected), paramName);
+
+            return value;
+        }
+
+        [DebuggerStepThrough]
+        public T IsNot<T>(T value, T expected, string paramName = Param.DefaultName) where T : IEquatable<T>
+        {
+            if (!Ensure.IsActive)
+                return value;
+
+            if (value.IsEq(expected))
+                throw new ArgumentException(ExceptionMessages.Comp_IsNot_Failed.Inject(value, expected), paramName);
+
+            return value;
+        }
+    }
+}

--- a/src/projects/EnsureThat/Extensions/EquatableExtensions.cs
+++ b/src/projects/EnsureThat/Extensions/EquatableExtensions.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace EnsureThat.Extensions
+{
+    internal static class EquatableExtensions
+    {
+        internal static bool IsEq<T>(this IEquatable<T> x, T y) => x.Equals(y);
+    }
+}

--- a/src/projects/EnsureThat/Extensions/EquatableExtensions.cs
+++ b/src/projects/EnsureThat/Extensions/EquatableExtensions.cs
@@ -1,9 +1,12 @@
 using System;
+using System.Collections.Generic;
 
 namespace EnsureThat.Extensions
 {
     internal static class EquatableExtensions
     {
         internal static bool IsEq<T>(this IEquatable<T> x, T y) => x.Equals(y);
+
+        internal static bool IsEq<T>(this T x, T y, IEqualityComparer<T> equalityComparer) => equalityComparer.Equals(x, y);
     }
 }

--- a/src/tests/UnitTests/EnsureComparableParamTests.cs
+++ b/src/tests/UnitTests/EnsureComparableParamTests.cs
@@ -277,7 +277,7 @@ namespace UnitTests
         public void AssertIsRangeToHighScenario<T>(T value, T limit, params Action[] actions)
             => ShouldThrow<ArgumentOutOfRangeException>(string.Format(ExceptionMessages.Comp_IsNotInRange_ToHigh, value, limit), actions);
 
-        public class CustomComparable : IComparable<CustomComparable>
+        public class CustomComparable : IComparable<CustomComparable>, IEquatable<CustomComparable>
         {
             private readonly int _value;
 
@@ -292,6 +292,36 @@ namespace UnitTests
                 var y = other._value;
 
                 return x.CompareTo(y);
+            }
+
+            public bool Equals(CustomComparable other)
+            {
+                if (ReferenceEquals(null, other)) return false;
+                if (ReferenceEquals(this, other)) return true;
+                return this._value == other._value;
+            }
+
+            public override bool Equals(object obj)
+            {
+                if (ReferenceEquals(null, obj)) return false;
+                if (ReferenceEquals(this, obj)) return true;
+                if (obj.GetType() != this.GetType()) return false;
+                return Equals((CustomComparable) obj);
+            }
+
+            public override int GetHashCode()
+            {
+                return this._value;
+            }
+
+            public static bool operator ==(CustomComparable left, CustomComparable right)
+            {
+                return Equals(left, right);
+            }
+
+            public static bool operator !=(CustomComparable left, CustomComparable right)
+            {
+                return !Equals(left, right);
             }
 
             public static implicit operator CustomComparable(int value) => new CustomComparable(value);


### PR DESCRIPTION
The library exposes `IComparer` operations, but where it's implemented, `IEquatable` can be more efficient. This review provides the option for developers to utilize that interface if desired/type-inferrence applicable