### PR TITLE
CollectionArg preserve input type in return value for HasAny and ContainsKey

### DIFF
--- a/src/projects/EnsureThat/CollectionArg.cs
+++ b/src/projects/EnsureThat/CollectionArg.cs
@@ -316,23 +316,6 @@ namespace EnsureThat
         }
 
         [DebuggerStepThrough]
-        public T ContainsKey<T, TKey, TValue>([NotNull, ValidatedNotNull]T value, TKey expectedKey, string paramName = Param.DefaultName)
-            where T : IDictionary<TKey, TValue>
-        {
-            if (!Ensure.IsActive)
-                return value;
-
-            Ensure.Any.IsNotNull(value, paramName);
-
-            if (!value.ContainsKey(expectedKey))
-                throw new ArgumentException(
-                    ExceptionMessages.Collections_ContainsKey_Failed.Inject(expectedKey),
-                    paramName);
-
-            return value;
-        }
-
-        [DebuggerStepThrough]
         public IList<T> HasAny<T>([NotNull, ValidatedNotNull]IList<T> value, Func<T, bool> predicate, string paramName = Param.DefaultName)
         {
             if (!Ensure.IsActive)
@@ -375,8 +358,7 @@ namespace EnsureThat
         }
 
         [DebuggerStepThrough]
-        public T HasAny<T, TItem>([NotNull, ValidatedNotNull]T value, Func<TItem, bool> predicate, string paramName = Param.DefaultName)
-            where T : ICollection<TItem>
+        public T HasAny<T, TItem>([NotNull, ValidatedNotNull]T value, Func<TItem, bool> predicate, string paramName = Param.DefaultName) where T : ICollection<TItem>
         {
             if (!Ensure.IsActive)
                 return value;

--- a/src/projects/EnsureThat/CollectionArg.cs
+++ b/src/projects/EnsureThat/CollectionArg.cs
@@ -316,6 +316,23 @@ namespace EnsureThat
         }
 
         [DebuggerStepThrough]
+        public T ContainsKey<T, TKey, TValue>([NotNull, ValidatedNotNull]T value, TKey expectedKey, string paramName = Param.DefaultName)
+            where T : IDictionary<TKey, TValue>
+        {
+            if (!Ensure.IsActive)
+                return value;
+
+            Ensure.Any.IsNotNull(value, paramName);
+
+            if (!value.ContainsKey(expectedKey))
+                throw new ArgumentException(
+                    ExceptionMessages.Collections_ContainsKey_Failed.Inject(expectedKey),
+                    paramName);
+
+            return value;
+        }
+
+        [DebuggerStepThrough]
         public IList<T> HasAny<T>([NotNull, ValidatedNotNull]IList<T> value, Func<T, bool> predicate, string paramName = Param.DefaultName)
         {
             if (!Ensure.IsActive)
@@ -345,6 +362,21 @@ namespace EnsureThat
 
         [DebuggerStepThrough]
         public T[] HasAny<T>([NotNull, ValidatedNotNull]T[] value, Func<T, bool> predicate, string paramName = Param.DefaultName)
+        {
+            if (!Ensure.IsActive)
+                return value;
+
+            Ensure.Any.IsNotNull(value, paramName);
+
+            if (!value.Any(predicate))
+                throw new ArgumentException(ExceptionMessages.Collections_Any_Failed, paramName);
+
+            return value;
+        }
+
+        [DebuggerStepThrough]
+        public T HasAny<T, TItem>([NotNull, ValidatedNotNull]T value, Func<TItem, bool> predicate, string paramName = Param.DefaultName)
+            where T : ICollection<TItem>
         {
             if (!Ensure.IsActive)
                 return value;

--- a/src/projects/EnsureThat/EnsureArg.Collections.cs
+++ b/src/projects/EnsureThat/EnsureArg.Collections.cs
@@ -96,5 +96,9 @@ namespace EnsureThat
         [DebuggerStepThrough]
         public static T[] Any<T>([NotNull, ValidatedNotNull]T[] value, Func<T, bool> predicate, string paramName = Param.DefaultName)
             => Ensure.Collection.HasAny(value, predicate, paramName);
+
+        [DebuggerStepThrough]
+        public static T Any<T, TItem>([NotNull, ValidatedNotNull]T value, Func<TItem, bool> predicate, string paramName = Param.DefaultName) where T : ICollection<TItem>
+            => Ensure.Collection.HasAny(value, predicate, paramName);
     }
 }


### PR DESCRIPTION
Part of #50 

Existing tests actually provide coverage for these already.