### PR TITLE
Use LongLength for Array

### DIFF
--- a/src/projects/EnsureThat/CollectionArg.cs
+++ b/src/projects/EnsureThat/CollectionArg.cs
@@ -163,8 +163,12 @@ namespace EnsureThat
 
             Ensure.Any.IsNotNull(value, paramName);
 
+#if NETSTANDARD1_1
             if (value.Length != expected)
-                throw new ArgumentException(
+# else
+            if (value.LongLength != expected)
+#endif
+            throw new ArgumentException(
                     ExceptionMessages.Collections_SizeIs_Failed.Inject(expected, value.Length),
                     paramName);
 

--- a/src/projects/EnsureThat/CollectionArg.cs
+++ b/src/projects/EnsureThat/CollectionArg.cs
@@ -165,7 +165,7 @@ namespace EnsureThat
 
 #if NETSTANDARD1_1
             if (value.Length != expected)
-# else
+#else
             if (value.LongLength != expected)
 #endif
             throw new ArgumentException(


### PR DESCRIPTION
For #61.

Unfortunately, we can't test this fully b/c it seems .NET runtime doesn't support arrays larger than int.MaxValue today :(. But the language support was added in core 1.2.
https://github.com/dotnet/corefx/issues/11926

Here's the test code I would've added, but the runtime throws complaining it cannot allocate an array larger than 2 GB. 
```
#if !(NETSTANDARD1_1)
        [Fact]
        public void SizeIs_When_matching_long_length_of_array_It_should_not_throw()
        {
            long length = int.MaxValue + 1L;
            var values = Array.CreateInstance(typeof(bool), length);

            ShouldNotThrow(
                () => Ensure.That(values, ParamName).SizeIs(values.Length),
                () => EnsureArg.SizeIs(values, values.Length, ParamName));
        }
#endif
```

Some more readings: https://stackoverflow.com/questions/30895549/cant-create-huge-arrays