### PR TITLE
Add [Pure] attribute

### DIFF
--- a/src/projects/EnsureThat/Annotations/JetBrains.cs
+++ b/src/projects/EnsureThat/Annotations/JetBrains.cs
@@ -51,4 +51,23 @@ namespace JetBrains.Annotations
         AttributeTargets.Delegate | AttributeTargets.Field | AttributeTargets.Event |
         AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.GenericParameter)]
     internal sealed class NotNullAttribute : Attribute { }
+    
+    /// <summary>
+    /// Indicates that a method does not make any observable state changes.
+    /// The same as <c>System.Diagnostics.Contracts.PureAttribute</c>.
+    /// </summary>
+    /// <example><code>
+    /// [Pure] int Multiply(int x, int y) => x * y;
+    /// 
+    /// void M() {
+    ///   Multiply(123, 42); // Waring: Return value of pure method is not used
+    /// }
+    /// </code></example>
+    /// <remarks>
+    /// <c>System.Diagnostics.Contracts.PureAttribute</c> is not available for NETSTANDARD1_1.
+    /// For consistency, using this version of the attribute for all profiles rather than 
+    /// just NETSTANDARD1_1.
+    /// </remarks>
+    [AttributeUsage(AttributeTargets.Method)]
+    internal sealed class PureAttribute : Attribute { }
 }

--- a/src/projects/EnsureThat/Ensure.cs
+++ b/src/projects/EnsureThat/Ensure.cs
@@ -1,42 +1,54 @@
 using System;
 using System.Diagnostics;
+using System.Diagnostics.Contracts;
 using JetBrains.Annotations;
 
 namespace EnsureThat
 {
     public static class Ensure
     {
+        [Pure]
         public static bool IsActive { get; private set; } = true;
 
         public static void Off() => IsActive = false;
 
         public static void On() => IsActive = true;
 
+        [Pure]
         public static AnyArg Any { get; } = new AnyArg();
 
+        [Pure]
         public static BoolArg Bool { get; } = new BoolArg();
 
+        [Pure]
         public static CollectionArg Collection { get; } = new CollectionArg();
 
+        [Pure]
         public static ComparableArg Comparable { get; } = new ComparableArg();
 
+        [Pure]
         public static GuidArg Guid { get; } = new GuidArg();
 
+        [Pure]
         public static StringArg String { get; } = new StringArg();
 
+        [Pure]
         public static TypeArg Type { get; } = new TypeArg();
 
         [DebuggerStepThrough]
+        [Pure]
         [Obsolete("Use contextual validation instead. E.g. Ensure.String.IsNotNull(value) or non contextual via EnsureArg instead. This version will eventually be removed.", false)]
         public static Param<T> That<T>([NoEnumeration]T value, string name = Param.DefaultName) => new Param<T>(name, value);
 
         [DebuggerStepThrough]
+        [Pure]
         [Obsolete("Use contextual validation instead. E.g. Ensure.String.IsNotNull(value) or non contextual via EnsureArg instead. This version will eventually be removed.", false)]
         public static Param<T> That<T>(Func<T> expression, string name = Param.DefaultName) => new Param<T>(
             name,
             expression.Invoke());
 
         [DebuggerStepThrough]
+        [Pure]
         [Obsolete("Use contextual validation instead. E.g. Ensure.String.IsNotNull(value) or non contextual via EnsureArg instead. This version will eventually be removed.", false)]
         public static TypeParam ThatTypeFor<T>(T value, string name = Param.DefaultName) => new TypeParam(name, value.GetType());
     }

--- a/src/projects/EnsureThat/Ensure.cs
+++ b/src/projects/EnsureThat/Ensure.cs
@@ -1,38 +1,29 @@
 using System;
 using System.Diagnostics;
-using System.Diagnostics.Contracts;
 using JetBrains.Annotations;
 
 namespace EnsureThat
 {
     public static class Ensure
     {
-        [Pure]
         public static bool IsActive { get; private set; } = true;
 
         public static void Off() => IsActive = false;
 
         public static void On() => IsActive = true;
 
-        [Pure]
         public static AnyArg Any { get; } = new AnyArg();
 
-        [Pure]
         public static BoolArg Bool { get; } = new BoolArg();
 
-        [Pure]
         public static CollectionArg Collection { get; } = new CollectionArg();
 
-        [Pure]
         public static ComparableArg Comparable { get; } = new ComparableArg();
 
-        [Pure]
         public static GuidArg Guid { get; } = new GuidArg();
 
-        [Pure]
         public static StringArg String { get; } = new StringArg();
 
-        [Pure]
         public static TypeArg Type { get; } = new TypeArg();
 
         [DebuggerStepThrough]

--- a/src/projects/EnsureThat/ExceptionFactory.cs
+++ b/src/projects/EnsureThat/ExceptionFactory.cs
@@ -1,15 +1,19 @@
 ﻿using System;
+using System.Diagnostics.Contracts;
 
 namespace EnsureThat
 {
     public static class ExceptionFactory
     {
+        [Pure]
         public static ArgumentException CreateForParamValidation(Param param, string message)
             => new ArgumentException(message, param.Name);
 
+        [Pure]
         public static ArgumentNullException CreateForParamNullValidation(Param param, string message)
             => new ArgumentNullException(param.Name, message);
 
+        [Pure]
         public static Exception CreateForComparableParamValidation<T>(Param<T> param, string message)
         {
             if (param.ExceptionFn != null)
@@ -23,6 +27,7 @@ namespace EnsureThat
                     : string.Concat(message, Environment.NewLine, param.ExtraMessageFn(param)));
         }
 
+        [Pure]
         public static Exception CreateForParamValidation<T>(Param<T> param, string message)
         {
             if (param.ExceptionFn != null)
@@ -35,6 +40,7 @@ namespace EnsureThat
                 param.Name);
         }
 
+        [Pure]
         public static Exception CreateForParamNullValidation<T>(Param<T> param, string message)
         {
             if (param.ExceptionFn != null)

--- a/src/projects/EnsureThat/ExceptionFactory.cs
+++ b/src/projects/EnsureThat/ExceptionFactory.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Diagnostics.Contracts;
+using JetBrains.Annotations;
 
 namespace EnsureThat
 {

--- a/src/projects/EnsureThat/ParamExtensions.cs
+++ b/src/projects/EnsureThat/ParamExtensions.cs
@@ -1,5 +1,5 @@
 using System;
-using System.Diagnostics.Contracts;
+using JetBrains.Annotations;
 
 namespace EnsureThat
 {

--- a/src/projects/EnsureThat/ParamExtensions.cs
+++ b/src/projects/EnsureThat/ParamExtensions.cs
@@ -1,9 +1,12 @@
 using System;
+using System.Diagnostics.Contracts;
 
 namespace EnsureThat
 {
+    // TODO: these will all be [Pure] when/if Param is immutable
     public static class ParamExtensions
     {
+        [Pure]
         public static Param<T> And<T>(this Param<T> param)
         {
             return param;


### PR DESCRIPTION
Helps R# to tell the user when they invoke a [Pure] method but do not use it's return value. Should only be used on methods that have no side effects.