### PR TITLE
Add [NotNull] Annotations based on implicit constraints

### DIFF
--- a/src/projects/EnsureThat/AnyArg.cs
+++ b/src/projects/EnsureThat/AnyArg.cs
@@ -7,6 +7,7 @@ namespace EnsureThat
 {
     public class AnyArg
     {
+        [NotNull]
         [DebuggerStepThrough]
         public T IsNotNull<T>([NoEnumeration, NotNull, ValidatedNotNull] T value, string paramName = Param.DefaultName)
         {

--- a/src/projects/EnsureThat/CollectionArg.cs
+++ b/src/projects/EnsureThat/CollectionArg.cs
@@ -11,6 +11,7 @@ namespace EnsureThat
 {
     public class CollectionArg
     {
+        [NotNull]
         [DebuggerStepThrough]
         public T HasItems<T>([NotNull, ValidatedNotNull]T value, string paramName = Param.DefaultName) where T : ICollection
         {
@@ -27,6 +28,7 @@ namespace EnsureThat
             return value;
         }
 
+        [NotNull]
         [DebuggerStepThrough]
         public ICollection<T> HasItems<T>([NotNull, ValidatedNotNull]ICollection<T> value, string paramName = Param.DefaultName)
         {
@@ -43,6 +45,7 @@ namespace EnsureThat
             return value;
         }
 
+        [NotNull]
         [DebuggerStepThrough]
         public IReadOnlyCollection<T> HasItems<T>([NotNull, ValidatedNotNull]IReadOnlyCollection<T> value, string paramName = Param.DefaultName)
         {
@@ -59,6 +62,7 @@ namespace EnsureThat
             return value;
         }
 
+        [NotNull]
         [DebuggerStepThrough]
         public IReadOnlyList<T> HasItems<T>([NotNull, ValidatedNotNull]IReadOnlyList<T> value, string paramName = Param.DefaultName)
         {
@@ -75,6 +79,7 @@ namespace EnsureThat
             return value;
         }
 
+        [NotNull]
         [DebuggerStepThrough]
         public ISet<T> HasItems<T>([NotNull, ValidatedNotNull]ISet<T> value, string paramName = Param.DefaultName)
         {
@@ -91,6 +96,7 @@ namespace EnsureThat
             return value;
         }
 
+        [NotNull]
         [DebuggerStepThrough]
         public T[] HasItems<T>([NotNull, ValidatedNotNull]T[] value, string paramName = Param.DefaultName)
         {
@@ -107,6 +113,7 @@ namespace EnsureThat
             return value;
         }
 
+        [NotNull]
         [DebuggerStepThrough]
         public IList<T> HasItems<T>([NotNull, ValidatedNotNull] IList<T> value, string paramName = Param.DefaultName)
         {
@@ -123,6 +130,7 @@ namespace EnsureThat
             return value;
         }
 
+        [NotNull]
         [DebuggerStepThrough]
         public IDictionary<TKey, TValue> HasItems<TKey, TValue>([NotNull, ValidatedNotNull]IDictionary<TKey, TValue> value, string paramName = Param.DefaultName)
         {
@@ -139,6 +147,7 @@ namespace EnsureThat
             return value;
         }
 
+        [NotNull]
         [DebuggerStepThrough]
         public T[] SizeIs<T>([NotNull, ValidatedNotNull]T[] value, int expected, string paramName = Param.DefaultName)
         {
@@ -155,6 +164,7 @@ namespace EnsureThat
             return value;
         }
 
+        [NotNull]
         [DebuggerStepThrough]
         public T[] SizeIs<T>([NotNull, ValidatedNotNull]T[] value, long expected, string paramName = Param.DefaultName)
         {
@@ -171,6 +181,7 @@ namespace EnsureThat
             return value;
         }
 
+        [NotNull]
         [DebuggerStepThrough]
         public T SizeIs<T>([NotNull, ValidatedNotNull]T value, int expected, string paramName = Param.DefaultName) where T : ICollection
         {
@@ -187,6 +198,7 @@ namespace EnsureThat
             return value;
         }
 
+        [NotNull]
         [DebuggerStepThrough]
         public T SizeIs<T>([NotNull, ValidatedNotNull]T value, long expected, string paramName = Param.DefaultName) where T : ICollection
         {
@@ -203,6 +215,7 @@ namespace EnsureThat
             return value;
         }
 
+        [NotNull]
         [DebuggerStepThrough]
         public ICollection<T> SizeIs<T>([NotNull, ValidatedNotNull]ICollection<T> value, int expected, string paramName = Param.DefaultName)
         {
@@ -219,6 +232,7 @@ namespace EnsureThat
             return value;
         }
 
+        [NotNull]
         [DebuggerStepThrough]
         public ICollection<T> SizeIs<T>([NotNull, ValidatedNotNull]ICollection<T> value, long expected, string paramName = Param.DefaultName)
         {
@@ -235,6 +249,7 @@ namespace EnsureThat
             return value;
         }
 
+        [NotNull]
         [DebuggerStepThrough]
         public IList<T> SizeIs<T>([NotNull, ValidatedNotNull] IList<T> value, int expected, string paramName = Param.DefaultName)
         {
@@ -251,6 +266,7 @@ namespace EnsureThat
             return value;
         }
 
+        [NotNull]
         [DebuggerStepThrough]
         public IList<T> SizeIs<T>([NotNull, ValidatedNotNull]IList<T> value, long expected, string paramName = Param.DefaultName)
         {
@@ -267,6 +283,7 @@ namespace EnsureThat
             return value;
         }
 
+        [NotNull]
         [DebuggerStepThrough]
         public IDictionary<TKey, TValue> SizeIs<TKey, TValue>([NotNull, ValidatedNotNull]IDictionary<TKey, TValue> value, int expected, string paramName = Param.DefaultName)
         {
@@ -283,6 +300,7 @@ namespace EnsureThat
             return value;
         }
 
+        [NotNull]
         [DebuggerStepThrough]
         public IDictionary<TKey, TValue> SizeIs<TKey, TValue>([NotNull, ValidatedNotNull]IDictionary<TKey, TValue> value, long expected, string paramName = Param.DefaultName)
         {
@@ -299,6 +317,7 @@ namespace EnsureThat
             return value;
         }
 
+        [NotNull]
         [DebuggerStepThrough]
         public IDictionary<TKey, TValue> ContainsKey<TKey, TValue>([NotNull, ValidatedNotNull]IDictionary<TKey, TValue> value, TKey expectedKey, string paramName = Param.DefaultName)
         {
@@ -315,6 +334,7 @@ namespace EnsureThat
             return value;
         }
 
+        [NotNull]
         [DebuggerStepThrough]
         public IList<T> HasAny<T>([NotNull, ValidatedNotNull]IList<T> value, Func<T, bool> predicate, string paramName = Param.DefaultName)
         {
@@ -329,6 +349,7 @@ namespace EnsureThat
             return value;
         }
 
+        [NotNull]
         [DebuggerStepThrough]
         public ICollection<T> HasAny<T>([NotNull, ValidatedNotNull]ICollection<T> value, Func<T, bool> predicate, string paramName = Param.DefaultName)
         {
@@ -343,6 +364,7 @@ namespace EnsureThat
             return value;
         }
 
+        [NotNull]
         [DebuggerStepThrough]
         public T[] HasAny<T>([NotNull, ValidatedNotNull]T[] value, Func<T, bool> predicate, string paramName = Param.DefaultName)
         {

--- a/src/projects/EnsureThat/ComparableArg.cs
+++ b/src/projects/EnsureThat/ComparableArg.cs
@@ -1,13 +1,15 @@
 ﻿using System;
 using System.Diagnostics;
 using EnsureThat.Extensions;
+using JetBrains.Annotations;
 
 namespace EnsureThat
 {
     public class ComparableArg
     {
+        [NotNull]
         [DebuggerStepThrough]
-        public T Is<T>(T value, T expected, string paramName = Param.DefaultName) where T : IComparable<T>
+        public T Is<T>([NotNull] T value, T expected, string paramName = Param.DefaultName) where T : IComparable<T>
         {
             if (!Ensure.IsActive)
                 return value;
@@ -18,8 +20,9 @@ namespace EnsureThat
             return value;
         }
 
+        [NotNull]
         [DebuggerStepThrough]
-        public T IsNot<T>(T value, T expected, string paramName = Param.DefaultName) where T : IComparable<T>
+        public T IsNot<T>([NotNull] T value, T expected, string paramName = Param.DefaultName) where T : IComparable<T>
         {
             if (!Ensure.IsActive)
                 return value;
@@ -30,8 +33,9 @@ namespace EnsureThat
             return value;
         }
 
+        [NotNull]
         [DebuggerStepThrough]
-        public T IsLt<T>(T value, T limit, string paramName = Param.DefaultName) where T : IComparable<T>
+        public T IsLt<T>([NotNull] T value, T limit, string paramName = Param.DefaultName) where T : IComparable<T>
         {
             if (!Ensure.IsActive)
                 return value;
@@ -42,8 +46,9 @@ namespace EnsureThat
             return value;
         }
 
+        [NotNull]
         [DebuggerStepThrough]
-        public T IsLte<T>(T value, T limit, string paramName = Param.DefaultName) where T : IComparable<T>
+        public T IsLte<T>([NotNull] T value, T limit, string paramName = Param.DefaultName) where T : IComparable<T>
         {
             if (!Ensure.IsActive)
                 return value;
@@ -54,8 +59,9 @@ namespace EnsureThat
             return value;
         }
 
+        [NotNull]
         [DebuggerStepThrough]
-        public T IsGt<T>(T value, T limit, string paramName = Param.DefaultName) where T : IComparable<T>
+        public T IsGt<T>([NotNull] T value, T limit, string paramName = Param.DefaultName) where T : IComparable<T>
         {
             if (!Ensure.IsActive)
                 return value;
@@ -66,8 +72,9 @@ namespace EnsureThat
             return value;
         }
 
+        [NotNull]
         [DebuggerStepThrough]
-        public T IsGte<T>(T value, T limit, string paramName = Param.DefaultName) where T : IComparable<T>
+        public T IsGte<T>([NotNull] T value, T limit, string paramName = Param.DefaultName) where T : IComparable<T>
         {
             if (!Ensure.IsActive)
                 return value;
@@ -78,8 +85,9 @@ namespace EnsureThat
             return value;
         }
 
+        [NotNull]
         [DebuggerStepThrough]
-        public T IsInRange<T>(T value, T min, T max, string paramName = Param.DefaultName) where T : IComparable<T>
+        public T IsInRange<T>([NotNull] T value, T min, T max, string paramName = Param.DefaultName) where T : IComparable<T>
         {
             if (!Ensure.IsActive)
                 return value;

--- a/src/projects/EnsureThat/Ensure.cs
+++ b/src/projects/EnsureThat/Ensure.cs
@@ -12,18 +12,25 @@ namespace EnsureThat
 
         public static void On() => IsActive = true;
 
+        [NotNull]
         public static AnyArg Any { get; } = new AnyArg();
 
+        [NotNull]
         public static BoolArg Bool { get; } = new BoolArg();
 
+        [NotNull]
         public static CollectionArg Collection { get; } = new CollectionArg();
 
+        [NotNull]
         public static ComparableArg Comparable { get; } = new ComparableArg();
 
+        [NotNull]
         public static GuidArg Guid { get; } = new GuidArg();
 
+        [NotNull]
         public static StringArg String { get; } = new StringArg();
 
+        [NotNull]
         public static TypeArg Type { get; } = new TypeArg();
 
         [DebuggerStepThrough]
@@ -32,12 +39,12 @@ namespace EnsureThat
 
         [DebuggerStepThrough]
         [Obsolete("Use contextual validation instead. E.g. Ensure.String.IsNotNull(value) or non contextual via EnsureArg instead. This version will eventually be removed.", false)]
-        public static Param<T> That<T>(Func<T> expression, string name = Param.DefaultName) => new Param<T>(
+        public static Param<T> That<T>([NotNull] Func<T> expression, string name = Param.DefaultName) => new Param<T>(
             name,
             expression.Invoke());
 
         [DebuggerStepThrough]
         [Obsolete("Use contextual validation instead. E.g. Ensure.String.IsNotNull(value) or non contextual via EnsureArg instead. This version will eventually be removed.", false)]
-        public static TypeParam ThatTypeFor<T>(T value, string name = Param.DefaultName) => new TypeParam(name, value.GetType());
+        public static TypeParam ThatTypeFor<T>([NotNull] T value, string name = Param.DefaultName) => new TypeParam(name, value.GetType());
     }
 }

--- a/src/projects/EnsureThat/EnsureArg.Collections.cs
+++ b/src/projects/EnsureThat/EnsureArg.Collections.cs
@@ -9,90 +9,112 @@ namespace EnsureThat
 {
     public static partial class EnsureArg
     {
+        [NotNull]
         [DebuggerStepThrough]
         public static T HasItems<T>([NotNull, ValidatedNotNull] T value, string paramName = Param.DefaultName) where T : ICollection
             => Ensure.Collection.HasItems(value, paramName);
 
+        [NotNull]
         [DebuggerStepThrough]
         public static ICollection<T> HasItems<T>([NotNull, ValidatedNotNull]ICollection<T> value, string paramName = Param.DefaultName)
             => Ensure.Collection.HasItems(value, paramName);
 
+        [NotNull]
         [DebuggerStepThrough]
         public static IReadOnlyCollection<T> HasItems<T>([NotNull, ValidatedNotNull]IReadOnlyCollection<T> value, string paramName = Param.DefaultName)
             => Ensure.Collection.HasItems(value, paramName);
 
+        [NotNull]
         [DebuggerStepThrough]
         public static IReadOnlyList<T> HasItems<T>([NotNull, ValidatedNotNull]IReadOnlyList<T> value, string paramName = Param.DefaultName)
             => Ensure.Collection.HasItems(value, paramName);
 
+        [NotNull]
         [DebuggerStepThrough]
         public static ISet<T> HasItems<T>([NotNull, ValidatedNotNull]ISet<T> value, string paramName = Param.DefaultName)
             => Ensure.Collection.HasItems(value, paramName);
 
+        [NotNull]
         [DebuggerStepThrough]
         public static T[] HasItems<T>([NotNull, ValidatedNotNull]T[] value, string paramName = Param.DefaultName)
             => Ensure.Collection.HasItems(value, paramName);
 
+        [NotNull]
         [DebuggerStepThrough]
         public static IList<T> HasItems<T>([NotNull, ValidatedNotNull] IList<T> value, string paramName = Param.DefaultName)
             => Ensure.Collection.HasItems(value, paramName);
 
+        [NotNull]
         [DebuggerStepThrough]
         public static IDictionary<TKey, TValue> HasItems<TKey, TValue>([NotNull, ValidatedNotNull]IDictionary<TKey, TValue> value, string paramName = Param.DefaultName)
             => Ensure.Collection.HasItems(value, paramName);
 
+        [NotNull]
         [DebuggerStepThrough]
         public static T[] SizeIs<T>([NotNull, ValidatedNotNull]T[] value, int expected, string paramName = Param.DefaultName)
             => Ensure.Collection.SizeIs(value, expected, paramName);
 
+        [NotNull]
         [DebuggerStepThrough]
         public static T[] SizeIs<T>([NotNull, ValidatedNotNull]T[] value, long expected, string paramName = Param.DefaultName)
             => Ensure.Collection.SizeIs(value, expected, paramName);
 
+        [NotNull]
         [DebuggerStepThrough]
         public static T SizeIs<T>([NotNull, ValidatedNotNull]T value, int expected, string paramName = Param.DefaultName) where T : ICollection
             => Ensure.Collection.SizeIs(value, expected, paramName);
 
+        [NotNull]
         [DebuggerStepThrough]
         public static T SizeIs<T>([NotNull, ValidatedNotNull]T value, long expected, string paramName = Param.DefaultName) where T : ICollection
             => Ensure.Collection.SizeIs(value, expected, paramName);
 
+        [NotNull]
         [DebuggerStepThrough]
         public static ICollection<T> SizeIs<T>([NotNull, ValidatedNotNull]ICollection<T> value, int expected, string paramName = Param.DefaultName)
             => Ensure.Collection.SizeIs(value, expected, paramName);
 
+        [NotNull]
         [DebuggerStepThrough]
         public static ICollection<T> SizeIs<T>([NotNull, ValidatedNotNull]ICollection<T> value, long expected, string paramName = Param.DefaultName)
             => Ensure.Collection.SizeIs(value, expected, paramName);
 
+        [NotNull]
         [DebuggerStepThrough]
         public static IList<T> SizeIs<T>([NotNull, ValidatedNotNull] IList<T> value, int expected, string paramName = Param.DefaultName)
             => Ensure.Collection.SizeIs(value, expected, paramName);
 
+        [NotNull]
         [DebuggerStepThrough]
         public static IList<T> SizeIs<T>([NotNull, ValidatedNotNull]IList<T> value, long expected, string paramName = Param.DefaultName)
             => Ensure.Collection.SizeIs(value, expected, paramName);
 
+        [NotNull]
         [DebuggerStepThrough]
         public static IDictionary<TKey, TValue> SizeIs<TKey, TValue>([NotNull, ValidatedNotNull]IDictionary<TKey, TValue> value, int expected, string paramName = Param.DefaultName)
             => Ensure.Collection.SizeIs(value, expected, paramName);
 
+        [NotNull]
         [DebuggerStepThrough]
         public static IDictionary<TKey, TValue> SizeIs<TKey, TValue>([NotNull, ValidatedNotNull]IDictionary<TKey, TValue> value, long expected, string paramName = Param.DefaultName)
             => Ensure.Collection.SizeIs(value, expected, paramName);
 
+        [NotNull]
         [DebuggerStepThrough]
         public static IDictionary<TKey, TValue> ContainsKey<TKey, TValue>([NotNull, ValidatedNotNull]IDictionary<TKey, TValue> value, TKey expectedKey, string paramName = Param.DefaultName)
             => Ensure.Collection.ContainsKey(value, expectedKey, paramName);
 
+        [NotNull]
         [DebuggerStepThrough]
         public static IList<T> Any<T>([NotNull, ValidatedNotNull] IList<T> value, Func<T, bool> predicate, string paramName = Param.DefaultName)
             => Ensure.Collection.HasAny(value, predicate, paramName);
 
+        [NotNull]
         [DebuggerStepThrough]
         public static ICollection<T> Any<T>([NotNull, ValidatedNotNull]ICollection<T> value, Func<T, bool> predicate, string paramName = Param.DefaultName)
             => Ensure.Collection.HasAny(value, predicate, paramName);
 
+        [NotNull]
         [DebuggerStepThrough]
         public static T[] Any<T>([NotNull, ValidatedNotNull]T[] value, Func<T, bool> predicate, string paramName = Param.DefaultName)
             => Ensure.Collection.HasAny(value, predicate, paramName);

--- a/src/projects/EnsureThat/EnsureArg.Comparables.cs
+++ b/src/projects/EnsureThat/EnsureArg.Comparables.cs
@@ -1,36 +1,44 @@
 ﻿using System;
 using System.Diagnostics;
+using JetBrains.Annotations;
 
 namespace EnsureThat
 {
     public static partial class EnsureArg
     {
+        [NotNull]
         [DebuggerStepThrough]
-        public static T Is<T>(T value, T expected, string paramName = Param.DefaultName) where T : IComparable<T>
+        public static T Is<T>([NotNull] T value, T expected, string paramName = Param.DefaultName) where T : IComparable<T>
             => Ensure.Comparable.Is(value, expected, paramName);
 
+        [NotNull]
         [DebuggerStepThrough]
-        public static T IsNot<T>(T value, T expected, string paramName = Param.DefaultName) where T : IComparable<T>
+        public static T IsNot<T>([NotNull] T value, T expected, string paramName = Param.DefaultName) where T : IComparable<T>
             => Ensure.Comparable.IsNot(value, expected, paramName);
 
+        [NotNull]
         [DebuggerStepThrough]
-        public static T IsLt<T>(T value, T limit, string paramName = Param.DefaultName) where T : IComparable<T>
+        public static T IsLt<T>([NotNull] T value, T limit, string paramName = Param.DefaultName) where T : IComparable<T>
             => Ensure.Comparable.IsLt(value, limit, paramName);
 
+        [NotNull]
         [DebuggerStepThrough]
-        public static T IsLte<T>(T value, T limit, string paramName = Param.DefaultName) where T : IComparable<T>
+        public static T IsLte<T>([NotNull] T value, T limit, string paramName = Param.DefaultName) where T : IComparable<T>
             => Ensure.Comparable.IsLte(value, limit, paramName);
 
+        [NotNull]
         [DebuggerStepThrough]
-        public static T IsGt<T>(T value, T limit, string paramName = Param.DefaultName) where T : IComparable<T>
+        public static T IsGt<T>([NotNull] T value, T limit, string paramName = Param.DefaultName) where T : IComparable<T>
             => Ensure.Comparable.IsGt(value, limit, paramName);
 
+        [NotNull]
         [DebuggerStepThrough]
-        public static T IsGte<T>(T value, T limit, string paramName = Param.DefaultName) where T : IComparable<T>
+        public static T IsGte<T>([NotNull] T value, T limit, string paramName = Param.DefaultName) where T : IComparable<T>
             => Ensure.Comparable.IsGte(value, limit, paramName);
 
+        [NotNull]
         [DebuggerStepThrough]
-        public static T IsInRange<T>(T value, T min, T max, string paramName = Param.DefaultName) where T : IComparable<T>
+        public static T IsInRange<T>([NotNull] T value, T min, T max, string paramName = Param.DefaultName) where T : IComparable<T>
             => Ensure.Comparable.IsInRange(value, min, max, paramName);
     }
 }

--- a/src/projects/EnsureThat/EnsureArg.Objects.cs
+++ b/src/projects/EnsureThat/EnsureArg.Objects.cs
@@ -6,6 +6,7 @@ namespace EnsureThat
 {
     public static partial class EnsureArg
     {
+        [NotNull]
         [DebuggerStepThrough]
         public static T IsNotNull<T>([NoEnumeration, NotNull, ValidatedNotNull] T value, string paramName = Param.DefaultName)
             => Ensure.Any.IsNotNull(value, paramName);

--- a/src/projects/EnsureThat/EnsureArg.Strings.cs
+++ b/src/projects/EnsureThat/EnsureArg.Strings.cs
@@ -8,10 +8,12 @@ namespace EnsureThat
 {
     public static partial class EnsureArg
     {
+        [NotNull]
         [DebuggerStepThrough]
         public static string IsNotNullOrWhiteSpace([NotNull, ValidatedNotNull] string value, string paramName = Param.DefaultName)
             => Ensure.String.IsNotNullOrWhiteSpace(value, paramName);
 
+        [NotNull]
         [DebuggerStepThrough]
         public static string IsNotNullOrEmpty([NotNull, ValidatedNotNull] string value, string paramName = Param.DefaultName)
             => Ensure.String.IsNotNullOrEmpty(value, paramName);
@@ -20,6 +22,7 @@ namespace EnsureThat
         public static string IsNotEmpty(string value, string paramName = Param.DefaultName)
             => Ensure.String.IsNotEmpty(value, paramName);
 
+        [NotNull]
         [DebuggerStepThrough]
         public static string HasLengthBetween([NotNull, ValidatedNotNull] string value, int minLength, int maxLength, string paramName = Param.DefaultName)
             => Ensure.String.HasLengthBetween(value, minLength, maxLength, paramName);
@@ -29,9 +32,10 @@ namespace EnsureThat
             => Ensure.String.Matches(value, match, paramName);
 
         [DebuggerStepThrough]
-        public static string Matches(string value, Regex match, string paramName = Param.DefaultName)
+        public static string Matches(string value, [NotNull] Regex match, string paramName = Param.DefaultName)
             => Ensure.String.Matches(value, match, paramName);
 
+        [NotNull]
         [DebuggerStepThrough]
         public static string SizeIs([NotNull, ValidatedNotNull] string value, int expected, string paramName = Param.DefaultName)
             => Ensure.String.SizeIs(value, expected, paramName);
@@ -52,6 +56,7 @@ namespace EnsureThat
         public static string IsNotEqualTo(string value, string expected, StringComparison comparison, string paramName = Param.DefaultName)
             => Ensure.String.IsNotEqualTo(value, expected, comparison, paramName);
 
+        [NotNull]
         [DebuggerStepThrough]
         public static string IsGuid([NotNull, ValidatedNotNull] string value, string paramName = Param.DefaultName)
             => Ensure.String.IsGuid(value, paramName);

--- a/src/projects/EnsureThat/EnsureArg.Types.cs
+++ b/src/projects/EnsureThat/EnsureArg.Types.cs
@@ -7,90 +7,112 @@ namespace EnsureThat
 {
     public static partial class EnsureArg
     {
+        [NotNull]
         [DebuggerStepThrough]
         public static Type IsInt([NotNull, ValidatedNotNull]Type param, string paramName = Param.DefaultName)
             => Ensure.Type.IsInt(param, paramName);
 
+        [NotNull]
         [DebuggerStepThrough]
         public static T IsInt<T>([NotNull, ValidatedNotNull]T param, string paramName = Param.DefaultName)
             => Ensure.Type.IsInt(param, paramName);
 
+        [NotNull]
         [DebuggerStepThrough]
         public static Type IsShort([NotNull, ValidatedNotNull]Type param, string paramName = Param.DefaultName)
             => Ensure.Type.IsShort(param, paramName);
 
+        [NotNull]
         [DebuggerStepThrough]
         public static T IsShort<T>([NotNull, ValidatedNotNull]T param, string paramName = Param.DefaultName)
             => Ensure.Type.IsShort(param, paramName);
 
+        [NotNull]
         [DebuggerStepThrough]
         public static Type IsDecimal([NotNull, ValidatedNotNull]Type param, string paramName = Param.DefaultName)
             => Ensure.Type.IsDecimal(param, paramName);
 
+        [NotNull]
         [DebuggerStepThrough]
         public static T IsDecimal<T>([NotNull, ValidatedNotNull]T param, string paramName = Param.DefaultName)
             => Ensure.Type.IsDecimal(param, paramName);
 
+        [NotNull]
         [DebuggerStepThrough]
         public static Type IsDouble([NotNull, ValidatedNotNull]Type param, string paramName = Param.DefaultName)
             => Ensure.Type.IsDouble(param, paramName);
 
+        [NotNull]
         [DebuggerStepThrough]
         public static T IsDouble<T>([NotNull, ValidatedNotNull]T param, string paramName = Param.DefaultName)
             => Ensure.Type.IsDouble(param, paramName);
 
+        [NotNull]
         [DebuggerStepThrough]
         public static Type IsFloat([NotNull, ValidatedNotNull]Type param, string paramName = Param.DefaultName)
             => Ensure.Type.IsFloat(param, paramName);
 
+        [NotNull]
         [DebuggerStepThrough]
         public static T IsFloat<T>([NotNull, ValidatedNotNull]T param, string paramName = Param.DefaultName)
             => Ensure.Type.IsFloat(param, paramName);
 
+        [NotNull]
         [DebuggerStepThrough]
         public static Type IsBool([NotNull, ValidatedNotNull]Type param, string paramName = Param.DefaultName)
             => Ensure.Type.IsBool(param, paramName);
 
+        [NotNull]
         [DebuggerStepThrough]
         public static T IsBool<T>([NotNull, ValidatedNotNull]T param, string paramName = Param.DefaultName)
             => Ensure.Type.IsBool(param, paramName);
 
+        [NotNull]
         [DebuggerStepThrough]
         public static Type IsDateTime([NotNull, ValidatedNotNull]Type param, string paramName = Param.DefaultName)
             => Ensure.Type.IsDateTime(param, paramName);
 
+        [NotNull]
         [DebuggerStepThrough]
         public static T IsDateTime<T>([NotNull, ValidatedNotNull]T param, string paramName = Param.DefaultName)
             => Ensure.Type.IsDateTime(param, paramName);
 
+        [NotNull]
         [DebuggerStepThrough]
         public static Type IsString([NotNull, ValidatedNotNull]Type param, string paramName = Param.DefaultName)
             => Ensure.Type.IsString(param, paramName);
 
+        [NotNull]
         [DebuggerStepThrough]
         public static T IsString<T>([NotNull, ValidatedNotNull]T param, string paramName = Param.DefaultName)
             => Ensure.Type.IsString(param, paramName);
 
+        [NotNull]
         [DebuggerStepThrough]
-        public static T IsOfType<T>([NotNull, ValidatedNotNull] T param, Type expectedType, string paramName = Param.DefaultName)
+        public static T IsOfType<T>([NotNull, ValidatedNotNull] T param, [NotNull] Type expectedType, string paramName = Param.DefaultName)
             => Ensure.Type.IsOfType(param, expectedType, paramName);
 
+        [NotNull]
         [DebuggerStepThrough]
-        public static Type IsOfType([NotNull, ValidatedNotNull]Type param, Type expectedType, string paramName = Param.DefaultName)
+        public static Type IsOfType([NotNull, ValidatedNotNull]Type param, [NotNull] Type expectedType, string paramName = Param.DefaultName)
             => Ensure.Type.IsOfType(param, expectedType, paramName);
 
+        [NotNull]
         [DebuggerStepThrough]
-        public static T IsNotOfType<T>([NotNull, ValidatedNotNull]T param, Type nonExpectedType, string paramName = Param.DefaultName)
+        public static T IsNotOfType<T>([NotNull, ValidatedNotNull]T param, [NotNull] Type nonExpectedType, string paramName = Param.DefaultName)
             => Ensure.Type.IsNotOfType(param, nonExpectedType, paramName);
 
+        [NotNull]
         [DebuggerStepThrough]
-        public static Type IsNotOfType([NotNull, ValidatedNotNull]Type param, Type nonExpectedType, string paramName = Param.DefaultName)
+        public static Type IsNotOfType([NotNull, ValidatedNotNull]Type param, [NotNull] Type nonExpectedType, string paramName = Param.DefaultName)
             => Ensure.Type.IsNotOfType(param, nonExpectedType, paramName);
 
+        [NotNull]
         [DebuggerStepThrough]
         public static T IsClass<T>([NotNull, ValidatedNotNull]T param, string paramName = Param.DefaultName)
             => Ensure.Type.IsClass(param, paramName);
 
+        [NotNull]
         [DebuggerStepThrough]
         public static Type IsClass([NotNull, ValidatedNotNull]Type param, string paramName = Param.DefaultName)
             => Ensure.Type.IsClass(param, paramName);

--- a/src/projects/EnsureThat/EnsureStringExtensions.cs
+++ b/src/projects/EnsureThat/EnsureStringExtensions.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics;
 using System.Text.RegularExpressions;
 using EnsureThat.Extensions;
+using JetBrains.Annotations;
 
 namespace EnsureThat
 {
@@ -56,7 +57,7 @@ namespace EnsureThat
         public static void Matches(this Param<string> param, string match) => Matches(param, new Regex(match));
 
         [DebuggerStepThrough]
-        public static void Matches(this Param<string> param, Regex match)
+        public static void Matches(this Param<string> param, [NotNull] Regex match)
         {
             if (!match.IsMatch(param.Value))
                 throw ExceptionFactory.CreateForParamValidation(param, ExceptionMessages.Strings_Matches_Failed.Inject(param.Value, match));

--- a/src/projects/EnsureThat/EnsureTypeExtensions.cs
+++ b/src/projects/EnsureThat/EnsureTypeExtensions.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics;
 using System.Reflection;
 using EnsureThat.Extensions;
+using JetBrains.Annotations;
 
 namespace EnsureThat
 {
@@ -9,20 +10,28 @@ namespace EnsureThat
     {
         private static class Types
         {
+            [NotNull]
             internal static readonly Type IntType = typeof(int);
 
+            [NotNull]
             internal static readonly Type ShortType = typeof(short);
 
+            [NotNull]
             internal static readonly Type DecimalType = typeof(decimal);
 
+            [NotNull]
             internal static readonly Type DoubleType = typeof(double);
 
+            [NotNull]
             internal static readonly Type FloatType = typeof(float);
 
+            [NotNull]
             internal static readonly Type BoolType = typeof(bool);
 
+            [NotNull]
             internal static readonly Type DateTimeType = typeof(DateTime);
 
+            [NotNull]
             internal static readonly Type StringType = typeof(string);
         }
 
@@ -51,7 +60,7 @@ namespace EnsureThat
         public static void IsString(this TypeParam param) => IsOfType(param, Types.StringType);
 
         [DebuggerStepThrough]
-        public static void IsOfType(this TypeParam param, Type type)
+        public static void IsOfType(this TypeParam param, [NotNull] Type type)
         {
             if (!Ensure.IsActive)
                 return;
@@ -80,7 +89,8 @@ namespace EnsureThat
                 throw ExceptionFactory.CreateForParamNullValidation(param,
                     ExceptionMessages.Types_IsClass_Failed_Null);
 
-            if (!param.Value.GetTypeInfo().IsClass)
+            if (param.Value == null
+                || !param.Value.GetTypeInfo().IsClass)
                 throw ExceptionFactory.CreateForParamValidation(param,
                     ExceptionMessages.Types_IsClass_Failed.Inject(param.Value.FullName));
         }

--- a/src/projects/EnsureThat/EnsureTypeExtensions.cs
+++ b/src/projects/EnsureThat/EnsureTypeExtensions.cs
@@ -10,28 +10,20 @@ namespace EnsureThat
     {
         private static class Types
         {
-            [NotNull]
             internal static readonly Type IntType = typeof(int);
-
-            [NotNull]
+            
             internal static readonly Type ShortType = typeof(short);
-
-            [NotNull]
+            
             internal static readonly Type DecimalType = typeof(decimal);
-
-            [NotNull]
+            
             internal static readonly Type DoubleType = typeof(double);
-
-            [NotNull]
+            
             internal static readonly Type FloatType = typeof(float);
-
-            [NotNull]
+            
             internal static readonly Type BoolType = typeof(bool);
-
-            [NotNull]
+            
             internal static readonly Type DateTimeType = typeof(DateTime);
-
-            [NotNull]
+            
             internal static readonly Type StringType = typeof(string);
         }
 

--- a/src/projects/EnsureThat/ExceptionFactory.cs
+++ b/src/projects/EnsureThat/ExceptionFactory.cs
@@ -1,15 +1,19 @@
 ﻿using System;
+using JetBrains.Annotations;
 
 namespace EnsureThat
 {
     public static class ExceptionFactory
     {
+        [NotNull]
         public static ArgumentException CreateForParamValidation(Param param, string message)
             => new ArgumentException(message, param.Name);
 
+        [NotNull]
         public static ArgumentNullException CreateForParamNullValidation(Param param, string message)
             => new ArgumentNullException(param.Name, message);
 
+        [NotNull]
         public static Exception CreateForComparableParamValidation<T>(Param<T> param, string message)
         {
             if (param.ExceptionFn != null)
@@ -23,6 +27,7 @@ namespace EnsureThat
                     : string.Concat(message, Environment.NewLine, param.ExtraMessageFn(param)));
         }
 
+        [NotNull]
         public static Exception CreateForParamValidation<T>(Param<T> param, string message)
         {
             if (param.ExceptionFn != null)
@@ -35,6 +40,7 @@ namespace EnsureThat
                 param.Name);
         }
 
+        [NotNull]
         public static Exception CreateForParamNullValidation<T>(Param<T> param, string message)
         {
             if (param.ExceptionFn != null)

--- a/src/projects/EnsureThat/Extensions/ComparableExtensions.cs
+++ b/src/projects/EnsureThat/Extensions/ComparableExtensions.cs
@@ -1,13 +1,14 @@
 using System;
+using JetBrains.Annotations;
 
 namespace EnsureThat.Extensions
 {
     internal static class ComparableExtensions
     {
-        internal static bool IsLt<T>(this IComparable<T> x, T y) => x.CompareTo(y) < 0;
+        internal static bool IsLt<T>([NotNull] this IComparable<T> x, T y) => x.CompareTo(y) < 0;
 
-        internal static bool IsEq<T>(this IComparable<T> x, T y) => x.CompareTo(y) == 0;
+        internal static bool IsEq<T>([NotNull] this IComparable<T> x, T y) => x.CompareTo(y) == 0;
 
-        internal static bool IsGt<T>(this IComparable<T> x, T y) => x.CompareTo(y) > 0;
+        internal static bool IsGt<T>([NotNull] this IComparable<T> x, T y) => x.CompareTo(y) > 0;
     }
 }

--- a/src/projects/EnsureThat/Extensions/ComparableExtensions.cs
+++ b/src/projects/EnsureThat/Extensions/ComparableExtensions.cs
@@ -5,10 +5,10 @@ namespace EnsureThat.Extensions
 {
     internal static class ComparableExtensions
     {
-        internal static bool IsLt<T>([NotNull] this IComparable<T> x, T y) => x.CompareTo(y) < 0;
+        internal static bool IsLt<T>(this IComparable<T> x, T y) => x.CompareTo(y) < 0;
 
-        internal static bool IsEq<T>([NotNull] this IComparable<T> x, T y) => x.CompareTo(y) == 0;
+        internal static bool IsEq<T>(this IComparable<T> x, T y) => x.CompareTo(y) == 0;
 
-        internal static bool IsGt<T>([NotNull] this IComparable<T> x, T y) => x.CompareTo(y) > 0;
+        internal static bool IsGt<T>(this IComparable<T> x, T y) => x.CompareTo(y) > 0;
     }
 }

--- a/src/projects/EnsureThat/Extensions/StringExtensions.cs
+++ b/src/projects/EnsureThat/Extensions/StringExtensions.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using JetBrains.Annotations;
 
 namespace EnsureThat.Extensions
 {
@@ -9,7 +10,7 @@ namespace EnsureThat.Extensions
             return string.Format(format, formattingArgs);
         }
 
-        internal static string Inject(this string format, params string[] formattingArgs)
+        internal static string Inject(this string format, [NotNull] params string[] formattingArgs)
         {
             return string.Format(format, formattingArgs.Select(a => a as object).ToArray());
         }

--- a/src/projects/EnsureThat/Extensions/StringExtensions.cs
+++ b/src/projects/EnsureThat/Extensions/StringExtensions.cs
@@ -10,7 +10,7 @@ namespace EnsureThat.Extensions
             return string.Format(format, formattingArgs);
         }
 
-        internal static string Inject(this string format, [NotNull] params string[] formattingArgs)
+        internal static string Inject(this string format, params string[] formattingArgs)
         {
             return string.Format(format, formattingArgs.Select(a => a as object).ToArray());
         }

--- a/src/projects/EnsureThat/ParamExtensions.cs
+++ b/src/projects/EnsureThat/ParamExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using JetBrains.Annotations;
 
 namespace EnsureThat
 {
@@ -16,7 +17,7 @@ namespace EnsureThat
             return param;
         }
 
-        public static Param<T> WithExtraMessageOf<T>(this Param<T> param, Func<string> messageFn)
+        public static Param<T> WithExtraMessageOf<T>(this Param<T> param, [NotNull] Func<string> messageFn)
         {
             param.ExtraMessageFn = p => messageFn();
 

--- a/src/projects/EnsureThat/StringArg.cs
+++ b/src/projects/EnsureThat/StringArg.cs
@@ -9,6 +9,7 @@ namespace EnsureThat
 {
     public class StringArg
     {
+        [NotNull]
         [DebuggerStepThrough]
         public string IsNotNullOrWhiteSpace([NotNull, ValidatedNotNull]string value, string paramName = Param.DefaultName)
         {
@@ -23,6 +24,7 @@ namespace EnsureThat
             return value;
         }
 
+        [NotNull]
         [DebuggerStepThrough]
         public string IsNotNullOrEmpty([NotNull, ValidatedNotNull]string value, string paramName = Param.DefaultName)
         {
@@ -49,6 +51,7 @@ namespace EnsureThat
             return value;
         }
 
+        [NotNull]
         [DebuggerStepThrough]
         public string HasLengthBetween([NotNull, ValidatedNotNull]string value, int minLength, int maxLength, string paramName = Param.DefaultName)
         {
@@ -73,7 +76,7 @@ namespace EnsureThat
             => Matches(value, new Regex(match), paramName);
 
         [DebuggerStepThrough]
-        public string Matches(string value, Regex match, string paramName = Param.DefaultName)
+        public string Matches(string value, [NotNull] Regex match, string paramName = Param.DefaultName)
         {
             if (!Ensure.IsActive)
                 return value;
@@ -84,6 +87,7 @@ namespace EnsureThat
             return value;
         }
 
+        [NotNull]
         [DebuggerStepThrough]
         public string SizeIs([NotNull, ValidatedNotNull]string value, int expected, string paramName = Param.DefaultName)
         {
@@ -146,6 +150,7 @@ namespace EnsureThat
             return value;
         }
 
+        [NotNull]
         [DebuggerStepThrough]
         public string IsGuid([NotNull, ValidatedNotNull]string value, string paramName = Param.DefaultName)
         {

--- a/src/projects/EnsureThat/TypeArg.cs
+++ b/src/projects/EnsureThat/TypeArg.cs
@@ -11,28 +11,20 @@ namespace EnsureThat
     {
         private static class Types
         {
-            [NotNull]
             internal static readonly Type IntType = typeof(int);
-
-            [NotNull]
+            
             internal static readonly Type ShortType = typeof(short);
-
-            [NotNull]
+            
             internal static readonly Type DecimalType = typeof(decimal);
-
-            [NotNull]
+            
             internal static readonly Type DoubleType = typeof(double);
-
-            [NotNull]
+            
             internal static readonly Type FloatType = typeof(float);
-
-            [NotNull]
+            
             internal static readonly Type BoolType = typeof(bool);
-
-            [NotNull]
+            
             internal static readonly Type DateTimeType = typeof(DateTime);
-
-            [NotNull]
+            
             internal static readonly Type StringType = typeof(string);
         }
 

--- a/src/projects/EnsureThat/TypeArg.cs
+++ b/src/projects/EnsureThat/TypeArg.cs
@@ -11,73 +11,98 @@ namespace EnsureThat
     {
         private static class Types
         {
+            [NotNull]
             internal static readonly Type IntType = typeof(int);
 
+            [NotNull]
             internal static readonly Type ShortType = typeof(short);
 
+            [NotNull]
             internal static readonly Type DecimalType = typeof(decimal);
 
+            [NotNull]
             internal static readonly Type DoubleType = typeof(double);
 
+            [NotNull]
             internal static readonly Type FloatType = typeof(float);
 
+            [NotNull]
             internal static readonly Type BoolType = typeof(bool);
 
+            [NotNull]
             internal static readonly Type DateTimeType = typeof(DateTime);
 
+            [NotNull]
             internal static readonly Type StringType = typeof(string);
         }
 
+        [NotNull]
         [DebuggerStepThrough]
         public Type IsInt([NotNull, ValidatedNotNull]Type param, string paramName = Param.DefaultName) => IsOfType(param, Types.IntType, paramName);
 
+        [NotNull]
         [DebuggerStepThrough]
         public T IsInt<T>([NotNull, ValidatedNotNull]T param, string paramName = Param.DefaultName) => IsOfType(param, Types.IntType, paramName);
 
+        [NotNull]
         [DebuggerStepThrough]
         public Type IsShort([NotNull, ValidatedNotNull]Type param, string paramName = Param.DefaultName) => IsOfType(param, Types.ShortType, paramName);
 
+        [NotNull]
         [DebuggerStepThrough]
         public T IsShort<T>([NotNull, ValidatedNotNull]T param, string paramName = Param.DefaultName) => IsOfType(param, Types.ShortType, paramName);
 
+        [NotNull]
         [DebuggerStepThrough]
         public Type IsDecimal([NotNull, ValidatedNotNull]Type param, string paramName = Param.DefaultName) => IsOfType(param, Types.DecimalType, paramName);
 
+        [NotNull]
         [DebuggerStepThrough]
         public T IsDecimal<T>([NotNull, ValidatedNotNull]T param, string paramName = Param.DefaultName) => IsOfType(param, Types.DecimalType, paramName);
 
+        [NotNull]
         [DebuggerStepThrough]
         public Type IsDouble([NotNull, ValidatedNotNull]Type param, string paramName = Param.DefaultName) => IsOfType(param, Types.DoubleType, paramName);
 
+        [NotNull]
         [DebuggerStepThrough]
         public T IsDouble<T>([NotNull, ValidatedNotNull]T param, string paramName = Param.DefaultName) => IsOfType(param, Types.DoubleType, paramName);
 
+        [NotNull]
         [DebuggerStepThrough]
         public Type IsFloat([NotNull, ValidatedNotNull]Type param, string paramName = Param.DefaultName) => IsOfType(param, Types.FloatType, paramName);
 
+        [NotNull]
         [DebuggerStepThrough]
         public T IsFloat<T>([NotNull, ValidatedNotNull]T param, string paramName = Param.DefaultName) => IsOfType(param, Types.FloatType, paramName);
 
+        [NotNull]
         [DebuggerStepThrough]
         public Type IsBool([NotNull, ValidatedNotNull]Type param, string paramName = Param.DefaultName) => IsOfType(param, Types.BoolType, paramName);
 
+        [NotNull]
         [DebuggerStepThrough]
         public T IsBool<T>([NotNull, ValidatedNotNull]T param, string paramName = Param.DefaultName) => IsOfType(param, Types.BoolType, paramName);
 
+        [NotNull]
         [DebuggerStepThrough]
         public Type IsDateTime([NotNull, ValidatedNotNull]Type param, string paramName = Param.DefaultName) => IsOfType(param, Types.DateTimeType, paramName);
 
+        [NotNull]
         [DebuggerStepThrough]
         public T IsDateTime<T>([NotNull, ValidatedNotNull]T param, string paramName = Param.DefaultName) => IsOfType(param, Types.DateTimeType, paramName);
 
+        [NotNull]
         [DebuggerStepThrough]
         public Type IsString([NotNull, ValidatedNotNull]Type param, string paramName = Param.DefaultName) => IsOfType(param, Types.StringType, paramName);
 
+        [NotNull]
         [DebuggerStepThrough]
         public T IsString<T>([NotNull, ValidatedNotNull]T param, string paramName = Param.DefaultName) => IsOfType(param, Types.StringType, paramName);
 
+        [NotNull]
         [DebuggerStepThrough]
-        public T IsOfType<T>([NotNull, ValidatedNotNull]T param, Type expectedType, string paramName = Param.DefaultName)
+        public T IsOfType<T>([NotNull, ValidatedNotNull]T param, [NotNull] Type expectedType, string paramName = Param.DefaultName)
         {
             if (!Ensure.IsActive)
                 return param;
@@ -89,8 +114,9 @@ namespace EnsureThat
             return param;
         }
 
+        [NotNull]
         [DebuggerStepThrough]
-        public Type IsOfType([NotNull, ValidatedNotNull]Type param, Type expectedType, string paramName = Param.DefaultName)
+        public Type IsOfType([NotNull, ValidatedNotNull]Type param, [NotNull] Type expectedType, string paramName = Param.DefaultName)
         {
             if (!Ensure.IsActive)
                 return param;
@@ -104,8 +130,9 @@ namespace EnsureThat
             return param;
         }
 
+        [NotNull]
         [DebuggerStepThrough]
-        public T IsNotOfType<T>([NotNull, ValidatedNotNull]T param, Type nonExpectedType, string paramName = Param.DefaultName)
+        public T IsNotOfType<T>([NotNull, ValidatedNotNull]T param, [NotNull] Type nonExpectedType, string paramName = Param.DefaultName)
         {
             if (!Ensure.IsActive)
                 return param;
@@ -117,8 +144,9 @@ namespace EnsureThat
             return param;
         }
 
+        [NotNull]
         [DebuggerStepThrough]
-        public Type IsNotOfType([NotNull, ValidatedNotNull]Type param, Type nonExpectedType, string paramName = Param.DefaultName)
+        public Type IsNotOfType([NotNull, ValidatedNotNull]Type param, [NotNull] Type nonExpectedType, string paramName = Param.DefaultName)
         {
             if (!Ensure.IsActive)
                 return param;
@@ -132,6 +160,7 @@ namespace EnsureThat
             return param;
         }
 
+        [NotNull]
         [DebuggerStepThrough]
         public T IsClass<T>([NotNull, ValidatedNotNull]T param, string paramName = Param.DefaultName)
         {
@@ -146,6 +175,7 @@ namespace EnsureThat
             return param;
         }
 
+        [NotNull]
         [DebuggerStepThrough]
         public Type IsClass([NotNull, ValidatedNotNull]Type param, string paramName = Param.DefaultName)
         {

--- a/src/projects/EnsureThat/TypeParam.cs
+++ b/src/projects/EnsureThat/TypeParam.cs
@@ -1,12 +1,14 @@
 using System;
+using JetBrains.Annotations;
 
 namespace EnsureThat
 {
     public class TypeParam : Param
     {
+        [NotNull]
         public readonly Type Type;
 
-        public TypeParam(string name, Type type)
+        public TypeParam(string name, [NotNull] Type type)
             : base(name)
         {
             Type = type;


### PR DESCRIPTION
(annotated based on current operations, not based on 'should' - needs review)

Used R#'s 'Pessimistic' analysis mode, which presumes all items not annotated with [NotNull] are annotated with [CanBeNull], to find places where something w/o nullability annotation was passed into a method/control structure that expected [NotNull].

For #48 