### PR TITLE
Contract annotation for True/False

### DIFF
--- a/src/projects/EnsureThat/Annotations/JetBrains.cs
+++ b/src/projects/EnsureThat/Annotations/JetBrains.cs
@@ -51,4 +51,65 @@ namespace JetBrains.Annotations
         AttributeTargets.Delegate | AttributeTargets.Field | AttributeTargets.Event |
         AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.GenericParameter)]
     internal sealed class NotNullAttribute : Attribute { }
+
+    /// <summary>
+    /// Describes dependency between method input and output.
+    /// </summary>
+    /// <syntax>
+    /// <p>Function Definition Table syntax:</p>
+    /// <list>
+    /// <item>FDT      ::= FDTRow [;FDTRow]*</item>
+    /// <item>FDTRow   ::= Input =&gt; Output | Output &lt;= Input</item>
+    /// <item>Input    ::= ParameterName: Value [, Input]*</item>
+    /// <item>Output   ::= [ParameterName: Value]* {halt|stop|void|nothing|Value}</item>
+    /// <item>Value    ::= true | false | null | notnull | canbenull</item>
+    /// </list>
+    /// If method has single input parameter, it's name could be omitted.<br/>
+    /// Using <c>halt</c> (or <c>void</c>/<c>nothing</c>, which is the same) for method output
+    /// means that the methos doesn't return normally (throws or terminates the process).<br/>
+    /// Value <c>canbenull</c> is only applicable for output parameters.<br/>
+    /// You can use multiple <c>[ContractAnnotation]</c> for each FDT row, or use single attribute
+    /// with rows separated by semicolon. There is no notion of order rows, all rows are checked
+    /// for applicability and applied per each program state tracked by R# analysis.<br/>
+    /// </syntax>
+    /// <examples><list>
+    /// <item><code>
+    /// [ContractAnnotation("=&gt; halt")]
+    /// public void TerminationMethod()
+    /// </code></item>
+    /// <item><code>
+    /// [ContractAnnotation("halt &lt;= condition: false")]
+    /// public void Assert(bool condition, string text) // regular assertion method
+    /// </code></item>
+    /// <item><code>
+    /// [ContractAnnotation("s:null =&gt; true")]
+    /// public bool IsNullOrEmpty(string s) // string.IsNullOrEmpty()
+    /// </code></item>
+    /// <item><code>
+    /// // A method that returns null if the parameter is null,
+    /// // and not null if the parameter is not null
+    /// [ContractAnnotation("null =&gt; null; notnull =&gt; notnull")]
+    /// public object Transform(object data) 
+    /// </code></item>
+    /// <item><code>
+    /// [ContractAnnotation("=&gt; true, result: notnull; =&gt; false, result: null")]
+    /// public bool TryParse(string s, out Person result)
+    /// </code></item>
+    /// </list></examples>
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    internal sealed class ContractAnnotationAttribute : Attribute
+    {
+        public ContractAnnotationAttribute([NotNull] string contract)
+          : this(contract, false) { }
+
+        public ContractAnnotationAttribute([NotNull] string contract, bool forceFullStates)
+        {
+            Contract = contract;
+            ForceFullStates = forceFullStates;
+        }
+
+        [NotNull] public string Contract { get; private set; }
+
+        public bool ForceFullStates { get; private set; }
+    }
 }

--- a/src/projects/EnsureThat/BoolArg.cs
+++ b/src/projects/EnsureThat/BoolArg.cs
@@ -1,11 +1,13 @@
 using System;
 using System.Diagnostics;
+using JetBrains.Annotations;
 
 namespace EnsureThat
 {
     public class BoolArg
     {
         [DebuggerStepThrough]
+        [ContractAnnotation("value:false=>halt; value:true=>true")]
         public bool IsTrue(bool value, string paramName = Param.DefaultName)
         {
             if (!Ensure.IsActive)
@@ -20,6 +22,7 @@ namespace EnsureThat
         }
 
         [DebuggerStepThrough]
+        [ContractAnnotation("value:true=>halt; value:false=>false")]
         public bool IsFalse(bool value, string paramName = Param.DefaultName)
         {
             if (!Ensure.IsActive)


### PR DESCRIPTION
Enables hints from R# for heuristically unreachable code/always true/false expressions.
If you want those. No particular _need_ to have them, but may be helpful to developers 😸 

![capture](https://user-images.githubusercontent.com/10776890/32807414-9c0ae5f4-c944-11e7-89ee-cb9365da61c9.PNG)
