### PR TITLE
Add RegexPatternAttribute

### DIFF
--- a/src/projects/EnsureThat/Annotations/JetBrains.cs
+++ b/src/projects/EnsureThat/Annotations/JetBrains.cs
@@ -33,6 +33,12 @@ using System;
 namespace JetBrains.Annotations
 {
     /// <summary>
+    /// Indicates that parameter is regular expression pattern.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Parameter)]
+    internal sealed class RegexPatternAttribute : Attribute { }
+
+    /// <summary>
     /// Indicates that IEnumerable, passed as parameter, is not enumerated.
     /// </summary>
     [AttributeUsage(AttributeTargets.Parameter)]

--- a/src/projects/EnsureThat/EnsureArg.Strings.cs
+++ b/src/projects/EnsureThat/EnsureArg.Strings.cs
@@ -25,7 +25,7 @@ namespace EnsureThat
             => Ensure.String.HasLengthBetween(value, minLength, maxLength, paramName);
 
         [DebuggerStepThrough]
-        public static string Matches(string value, string match, string paramName = Param.DefaultName)
+        public static string Matches(string value, [RegexPattern] string match, string paramName = Param.DefaultName)
             => Ensure.String.Matches(value, match, paramName);
 
         [DebuggerStepThrough]

--- a/src/projects/EnsureThat/EnsureStringExtensions.cs
+++ b/src/projects/EnsureThat/EnsureStringExtensions.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics;
 using System.Text.RegularExpressions;
 using EnsureThat.Extensions;
+using JetBrains.Annotations;
 
 namespace EnsureThat
 {
@@ -53,7 +54,7 @@ namespace EnsureThat
         }
 
         [DebuggerStepThrough]
-        public static void Matches(this Param<string> param, string match) => Matches(param, new Regex(match));
+        public static void Matches(this Param<string> param, [RegexPattern] string match) => Matches(param, new Regex(match));
 
         [DebuggerStepThrough]
         public static void Matches(this Param<string> param, Regex match)

--- a/src/projects/EnsureThat/StringArg.cs
+++ b/src/projects/EnsureThat/StringArg.cs
@@ -69,7 +69,7 @@ namespace EnsureThat
         }
 
         [DebuggerStepThrough]
-        public string Matches(string value, string match, string paramName = Param.DefaultName)
+        public string Matches(string value, [RegexPattern] string match, string paramName = Param.DefaultName)
             => Matches(value, new Regex(match), paramName);
 
         [DebuggerStepThrough]


### PR DESCRIPTION
Enables syntax highlighting on (inline) parameters that are Regex

![capture](https://user-images.githubusercontent.com/10776890/32807593-37b09a3a-c945-11e7-86a2-67d261c30d65.PNG)
