### PR TITLE
Adds support for IEnumerable<T> to EnumerableArg.HasItems

### DIFF
--- a/src/projects/EnsureThat/CollectionArg.cs
+++ b/src/projects/EnsureThat/CollectionArg.cs
@@ -30,6 +30,23 @@ namespace EnsureThat
 
         [NotNull]
         [DebuggerStepThrough]
+        public IEnumerable<T> HasItems<T>([ValidatedNotNull]IEnumerable<T> value, [InvokerParameterName] string paramName = Param.DefaultName)
+        {
+            if (!Ensure.IsActive)
+                return value;
+
+            Ensure.Any.IsNotNull(value, paramName);
+
+            if (!value.Any())
+                throw new ArgumentException(
+                    ExceptionMessages.Collections_HasItemsFailed,
+                    paramName);
+
+            return value;
+        }
+
+        [NotNull]
+        [DebuggerStepThrough]
         public ICollection<T> HasItems<T>([ValidatedNotNull]ICollection<T> value, [InvokerParameterName] string paramName = Param.DefaultName)
         {
             if (!Ensure.IsActive)
@@ -178,9 +195,9 @@ namespace EnsureThat
 #else
             if (value.LongLength != expected)
 #endif
-            throw new ArgumentException(
-                    ExceptionMessages.Collections_SizeIs_Failed.Inject(expected, value.Length),
-                    paramName);
+                throw new ArgumentException(
+                        ExceptionMessages.Collections_SizeIs_Failed.Inject(expected, value.Length),
+                        paramName);
 
             return value;
         }

--- a/src/projects/EnsureThat/EnsureArg.Collections.cs
+++ b/src/projects/EnsureThat/EnsureArg.Collections.cs
@@ -16,6 +16,11 @@ namespace EnsureThat
 
         [NotNull]
         [DebuggerStepThrough]
+        public static IEnumerable<T> HasItems<T>([ValidatedNotNull]IEnumerable<T> value, [InvokerParameterName] string paramName = Param.DefaultName)
+            => Ensure.Collection.HasItems(value, paramName);
+
+        [NotNull]
+        [DebuggerStepThrough]
         public static ICollection<T> HasItems<T>([ValidatedNotNull]ICollection<T> value, [InvokerParameterName] string paramName = Param.DefaultName)
             => Ensure.Collection.HasItems(value, paramName);
 

--- a/src/tests/UnitTests/EnsureCollectionParamsTests.cs
+++ b/src/tests/UnitTests/EnsureCollectionParamsTests.cs
@@ -49,6 +49,24 @@ namespace UnitTests
         }
 
         [Fact]
+        public void HasItems_WhenEmptyIEnumerable_ThrowsArgumentException()
+        {
+            IEnumerable<int> emptyCollection = new Collection<int>();
+
+            AssertIsEmptyCollection(
+                () => EnsureArg.HasItems(emptyCollection, ParamName));
+        }
+
+        [Fact]
+        public void HasItems_WhenNonEmptyIEnumerable_ShouldNotThrow()
+        {
+            IEnumerable<int> collection = new Collection<int> { 1, 2, 3 };
+
+            ShouldNotThrow(
+                () => EnsureArg.HasItems(collection, ParamName));
+        }
+
+        [Fact]
         public void HasItems_WhenEmptyICollection_ThrowsArgumentException()
         {
             ICollection<int> emptyCollection = new Collection<int>();


### PR DESCRIPTION
If you are using HasItems and your reference is of type IEnumerable<T> you need to append a .ToArray() or .ToList() in order for it to compile. This is mildly annoying and I felt that there is no reason HasItems should not support IEnumerable<T> directly.