### PR TITLE
[INCOMPLETE] Use the concrete type instead of the interface to avoid CallVirt

### DIFF
--- a/src/projects/EnsureThat/Ensure.cs
+++ b/src/projects/EnsureThat/Ensure.cs
@@ -17,7 +17,7 @@ namespace EnsureThat
             Collection = new DummyCollectionArg();
             Comparable = new DummyComparableArg();
             Guid = new DummyGuidArg();
-            String = new DummyStringArg();
+            //String = new DummyStringArg();
             Type = new DummyTypeArg();
         }
 
@@ -74,7 +74,7 @@ namespace EnsureThat
         /// Ensures for strings.
         /// </summary>
         [NotNull]
-        public static IStringArg String { get; set; } = new StringArg(ExceptionFactory);
+        public static StringArg String { get; set; } = new StringArg(ExceptionFactory);
 
         /// <summary>
         /// Ensures for types.


### PR DESCRIPTION
As-is this breaks on/off functionality. Was that still planning to be removed in v8?

As a side note, I realized that nuget packages have props/targets files. With these, it's possible for us to use `[ConditionalAttribute]` with a constant we define in the nuget-imported targets file (unless consumer specifies some `PropertyGroup` item that tells us not to. This would give us the 'Not' version we wanted for that.

If you're interested in that approach, I will do a proof of concept. If you're just getting rid of On/Off altogether I'm fine with that since no one seems to need it yet, and we can investigate the option later if/when someone asks.