### PR TITLE
Fix broken String.IsNotEmptyOrWhitespace

### DIFF
--- a/src/projects/EnsureThat/Enforcers/StringArg.cs
+++ b/src/projects/EnsureThat/Enforcers/StringArg.cs
@@ -52,12 +52,12 @@ namespace EnsureThat.Enforcers
             }
             foreach (var t in value)
             {
-                if (Char.IsWhiteSpace(t))
+                if (!Char.IsWhiteSpace(t))
                 {
-                    throw Ensure.ExceptionFactory.ArgumentException(ExceptionMessages.Strings_IsNotEmptyOrWhitespace_Failed, paramName, optsFn);
+                    return value; //succeed and return as soon as we see a non-whitespace character
                 }
             }
-            return value;
+            throw Ensure.ExceptionFactory.ArgumentException(ExceptionMessages.Strings_IsNotEmptyOrWhitespace_Failed, paramName, optsFn);
         }
 
         public string IsNotEmpty(string value, [InvokerParameterName] string paramName = null, OptsFn optsFn = null)

--- a/src/tests/UnitTests/EnsureStringParamTests.cs
+++ b/src/tests/UnitTests/EnsureStringParamTests.cs
@@ -90,6 +90,7 @@ namespace UnitTests
                 () => Ensure.That(value, ParamName).IsNotEmptyOrWhitespace(),
                 () => EnsureArg.IsNotEmptyOrWhitespace(value, ParamName));
         }
+
         [Fact]
         public void IsNotEmptyOrWhitespace_WhenWhitespace_ThrowsArgumentException()
         {
@@ -99,6 +100,16 @@ namespace UnitTests
                 () => Ensure.String.IsNotEmptyOrWhitespace(value, ParamName),
                 () => Ensure.That(value, ParamName).IsNotEmptyOrWhitespace(),
                 () => EnsureArg.IsNotEmptyOrWhitespace(value, ParamName));
+        }
+
+        [Fact]
+        public void IsNotEmptyOrWhitespace_WhenPartialWhitespace_It_should_not_throw()
+        {
+            string value = "  string with whitespace in it  ";
+            ShouldNotThrow(
+                () => Ensure.String.IsNotEmptyOrWhitespace(value, ParamName),
+                () => EnsureArg.IsNotEmptyOrWhitespace(value, ParamName),
+                () => Ensure.That(value, ParamName).IsNotEmptyOrWhitespace());
         }
 
         [Fact]


### PR DESCRIPTION
The code and tests related to #102 miss the case where a string has content.

This PR adds an extra case for that scenario and alters the current implementation accordingly.