### PR TITLE
Fix inconsistent WhiteSpace naming

### DIFF
--- a/src/projects/EnsureThat/Enforcers/StringArg.cs
+++ b/src/projects/EnsureThat/Enforcers/StringArg.cs
@@ -39,7 +39,7 @@ namespace EnsureThat.Enforcers
             return value;
         }
 
-        public string IsNotEmptyOrWhitespace(string value, [InvokerParameterName] string paramName = null, OptsFn optsFn = null)
+        public string IsNotEmptyOrWhiteSpace(string value, [InvokerParameterName] string paramName = null, OptsFn optsFn = null)
         {
             if (value == null) 
             {
@@ -48,7 +48,7 @@ namespace EnsureThat.Enforcers
 
             if (value.Length == 0)
             {
-                throw Ensure.ExceptionFactory.ArgumentException(ExceptionMessages.Strings_IsNotEmptyOrWhitespace_Failed, paramName, optsFn);
+                throw Ensure.ExceptionFactory.ArgumentException(ExceptionMessages.Strings_IsNotEmptyOrWhiteSpace_Failed, paramName, optsFn);
             }
             foreach (var t in value)
             {
@@ -57,7 +57,7 @@ namespace EnsureThat.Enforcers
                     return value; //succeed and return as soon as we see a non-whitespace character
                 }
             }
-            throw Ensure.ExceptionFactory.ArgumentException(ExceptionMessages.Strings_IsNotEmptyOrWhitespace_Failed, paramName, optsFn);
+            throw Ensure.ExceptionFactory.ArgumentException(ExceptionMessages.Strings_IsNotEmptyOrWhiteSpace_Failed, paramName, optsFn);
         }
 
         public string IsNotEmpty(string value, [InvokerParameterName] string paramName = null, OptsFn optsFn = null)

--- a/src/projects/EnsureThat/EnsureArg.Strings.cs
+++ b/src/projects/EnsureThat/EnsureArg.Strings.cs
@@ -22,8 +22,13 @@ namespace EnsureThat
         public static string IsNotNullOrEmpty([ValidatedNotNull] string value, [InvokerParameterName] string paramName = null, OptsFn optsFn = null)
             => Ensure.String.IsNotNullOrEmpty(value, paramName, optsFn);
 
+        public static string IsNotEmptyOrWhiteSpace(string value, [InvokerParameterName] string paramName = null, OptsFn optsFn = null)
+            => Ensure.String.IsNotEmptyOrWhiteSpace(value, paramName, optsFn);
+
+        [Obsolete("This method will soon be deprecated. Use IsNotEmptyOrWhiteSpace instead.")]
         public static string IsNotEmptyOrWhitespace(string value, [InvokerParameterName] string paramName = null, OptsFn optsFn = null)
-            => Ensure.String.IsNotEmptyOrWhitespace(value, paramName, optsFn);
+            => Ensure.String.IsNotEmptyOrWhiteSpace(value, paramName, optsFn);
+
         public static string IsNotEmpty(string value, [InvokerParameterName] string paramName = null, OptsFn optsFn = null)
             => Ensure.String.IsNotEmpty(value, paramName, optsFn);
 

--- a/src/projects/EnsureThat/EnsureThatStringExtensions.cs
+++ b/src/projects/EnsureThat/EnsureThatStringExtensions.cs
@@ -15,8 +15,13 @@ namespace EnsureThat
         public static void IsNotNullOrEmpty(this in StringParam param)
             => Ensure.String.IsNotNullOrEmpty(param.Value, param.Name, param.OptsFn);
 
+        public static void IsNotEmptyOrWhiteSpace(this in StringParam param)
+            => Ensure.String.IsNotEmptyOrWhiteSpace(param.Value, param.Name, param.OptsFn);
+
+        [Obsolete("This method will soon be deprecated. Use IsNotEmptyOrWhiteSpace instead.")]
         public static void IsNotEmptyOrWhitespace(this in StringParam param)
-            => Ensure.String.IsNotEmptyOrWhitespace(param.Value, param.Name, param.OptsFn);
+            => Ensure.String.IsNotEmptyOrWhiteSpace(param.Value, param.Name, param.OptsFn);
+
         public static void IsNotEmpty(this in StringParam param)
             => Ensure.String.IsNotEmpty(param.Value, param.Name, param.OptsFn);
 

--- a/src/projects/EnsureThat/ExceptionMessages.cs
+++ b/src/projects/EnsureThat/ExceptionMessages.cs
@@ -28,7 +28,7 @@
         public static string Strings_SizeIs_Failed { get; } = "Expected length '{0}' but found '{1}'.";
         public static string Strings_IsNotNullOrWhiteSpace_Failed { get; } = "The string can't be left empty, null or consist of only whitespaces.";
         public static string Strings_IsNotNullOrEmpty_Failed { get; } = "The string can't be null or empty.";
-        public static string Strings_IsNotEmptyOrWhitespace_Failed { get; } = "The string can't be empty or consist of only whitespace characters.";
+        public static string Strings_IsNotEmptyOrWhiteSpace_Failed { get; } = "The string can't be empty or consist of only whitespace characters.";
         public static string Strings_HasLengthBetween_Failed_ToShort { get; } = "The string is not long enough. Must be between '{0}' and '{1}' but was '{2}' characters long.";
         public static string Strings_HasLengthBetween_Failed_ToLong { get; } = "The string is too long. Must be between '{0}' and  '{1}'. Must be between '{0}' and '{1}' but was '{2}' characters long.";
         public static string Strings_Matches_Failed { get; } = "Value '{0}' does not match '{1}'";

--- a/src/tests/UnitTests/EnsureStringParamTests.cs
+++ b/src/tests/UnitTests/EnsureStringParamTests.cs
@@ -71,45 +71,45 @@ namespace UnitTests
         }
 
         [Fact]
-        public void IsNotEmptyOrWhitespace_WhenNull_It_should_not_throw()
+        public void IsNotEmptyOrWhiteSpace_WhenNull_It_should_not_throw()
         {
             string value = null;
             ShouldNotThrow(
-                () => Ensure.String.IsNotEmptyOrWhitespace(value, ParamName),
-                () => Ensure.That(value, ParamName).IsNotEmptyOrWhitespace(),
-                () => EnsureArg.IsNotEmptyOrWhitespace(value, ParamName));
+                () => Ensure.String.IsNotEmptyOrWhiteSpace(value, ParamName),
+                () => Ensure.That(value, ParamName).IsNotEmptyOrWhiteSpace(),
+                () => EnsureArg.IsNotEmptyOrWhiteSpace(value, ParamName));
         }
 
         [Fact]
-        public void IsNotEmptyOrWhitespace_WhenEmpty_ThrowsArgumentException()
+        public void IsNotEmptyOrWhiteSpace_WhenEmpty_ThrowsArgumentException()
         {
             string value = "";
             ShouldThrow<ArgumentException>(
-                ExceptionMessages.Strings_IsNotEmptyOrWhitespace_Failed,
-                () => Ensure.String.IsNotEmptyOrWhitespace(value, ParamName),
-                () => Ensure.That(value, ParamName).IsNotEmptyOrWhitespace(),
-                () => EnsureArg.IsNotEmptyOrWhitespace(value, ParamName));
+                ExceptionMessages.Strings_IsNotEmptyOrWhiteSpace_Failed,
+                () => Ensure.String.IsNotEmptyOrWhiteSpace(value, ParamName),
+                () => Ensure.That(value, ParamName).IsNotEmptyOrWhiteSpace(),
+                () => EnsureArg.IsNotEmptyOrWhiteSpace(value, ParamName));
         }
 
         [Fact]
-        public void IsNotEmptyOrWhitespace_WhenWhitespace_ThrowsArgumentException()
+        public void IsNotEmptyOrWhiteSpace_WhenWhiteSpace_ThrowsArgumentException()
         {
             string value = "        ";
             ShouldThrow<ArgumentException>(
-                ExceptionMessages.Strings_IsNotEmptyOrWhitespace_Failed,
-                () => Ensure.String.IsNotEmptyOrWhitespace(value, ParamName),
-                () => Ensure.That(value, ParamName).IsNotEmptyOrWhitespace(),
-                () => EnsureArg.IsNotEmptyOrWhitespace(value, ParamName));
+                ExceptionMessages.Strings_IsNotEmptyOrWhiteSpace_Failed,
+                () => Ensure.String.IsNotEmptyOrWhiteSpace(value, ParamName),
+                () => Ensure.That(value, ParamName).IsNotEmptyOrWhiteSpace(),
+                () => EnsureArg.IsNotEmptyOrWhiteSpace(value, ParamName));
         }
 
         [Fact]
-        public void IsNotEmptyOrWhitespace_WhenPartialWhitespace_It_should_not_throw()
+        public void IsNotEmptyOrWhiteSpace_WhenPartialWhiteSpace_It_should_not_throw()
         {
             string value = "  string with whitespace in it  ";
             ShouldNotThrow(
-                () => Ensure.String.IsNotEmptyOrWhitespace(value, ParamName),
-                () => EnsureArg.IsNotEmptyOrWhitespace(value, ParamName),
-                () => Ensure.That(value, ParamName).IsNotEmptyOrWhitespace());
+                () => Ensure.String.IsNotEmptyOrWhiteSpace(value, ParamName),
+                () => EnsureArg.IsNotEmptyOrWhiteSpace(value, ParamName),
+                () => Ensure.That(value, ParamName).IsNotEmptyOrWhiteSpace());
         }
 
         [Fact]


### PR DESCRIPTION
There's an inconsistent usage of the keyword _whitespace_. While for the `IsNotNullOrWhiteSpace` validation it's used with an upper S, for the `IsNotEmptyOrWhitespace` doesn't, so I just replaced all the occurrences of _Whitespace_ for _WhiteSpace_, even though I'd rather use the former.