### PR TITLE
Replace IEnumerable.Count() with .Any()

### DIFF
--- a/src/projects/EnsureThat/Enforcers/EnumerableArg.cs
+++ b/src/projects/EnsureThat/Enforcers/EnumerableArg.cs
@@ -20,7 +20,7 @@ namespace EnsureThat.Enforcers
         {
             Ensure.Any.IsNotNull(value, paramName);
 
-            if (value.Count() == 0)
+            if (!value.Any())
                 throw Ensure.ExceptionFactory.ArgumentException(
                     ExceptionMessages.Collections_HasItemsFailed,
                     paramName,
@@ -52,15 +52,9 @@ namespace EnsureThat.Enforcers
         {
             Ensure.Any.IsNotNull(value, paramName);
 
-#if NETSTANDARD1_1
             var count = value.LongCount();
 
             if (count != expected)
-#else
-            var count = value.LongCount();
-
-            if (count != expected)
-#endif
                 throw Ensure.ExceptionFactory.ArgumentException(
                     string.Format(ExceptionMessages.Collections_SizeIs_Failed, expected, count),
                     paramName,

--- a/src/projects/EnsureThat/Enforcers/EnumerableArg.cs
+++ b/src/projects/EnsureThat/Enforcers/EnumerableArg.cs
@@ -52,9 +52,15 @@ namespace EnsureThat.Enforcers
         {
             Ensure.Any.IsNotNull(value, paramName);
 
+#if NETSTANDARD1_1
             var count = value.LongCount();
 
             if (count != expected)
+#else
+            var count = value.LongCount();
+
+            if (count != expected)
+#endif
                 throw Ensure.ExceptionFactory.ArgumentException(
                     string.Format(ExceptionMessages.Collections_SizeIs_Failed, expected, count),
                     paramName,


### PR DESCRIPTION
Using `.Any()` may be slightly faster then `.Count()`. Because `Count()` method have to iterate through all elements of `IEnumerable` while for `Any()` iterating first element is enough.

Also there was suspicious `#if` directive with same code in both branches.