### PR TITLE
Readonly structs

### DIFF
--- a/src/projects/EnsureThat/EnsureThatCollectionExtensions.cs
+++ b/src/projects/EnsureThat/EnsureThatCollectionExtensions.cs
@@ -7,97 +7,97 @@ namespace EnsureThat
 {
     public static class EnsureThatCollectionExtensions
     {
-        public static void HasItems<T>(this Param<T> param) where T : class, ICollection
+        public static void HasItems<T>(this in Param<T> param) where T : class, ICollection
             => Ensure.Collection.HasItems(param.Value, param.Name, param.OptsFn);
 
-        public static void HasItems<T>(this Param<Collection<T>> param)
+        public static void HasItems<T>(this in Param<Collection<T>> param)
             => Ensure.Collection.HasItems(param.Value, param.Name, param.OptsFn);
 
-        public static void HasItems<T>(this Param<ICollection<T>> param)
+        public static void HasItems<T>(this in Param<ICollection<T>> param)
             => Ensure.Collection.HasItems(param.Value, param.Name, param.OptsFn);
 
-        public static void HasItems<T>(this Param<T[]> param)
+        public static void HasItems<T>(this in Param<T[]> param)
             => Ensure.Collection.HasItems(param.Value, param.Name, param.OptsFn);
 
-        public static void HasItems<T>(this Param<List<T>> param)
+        public static void HasItems<T>(this in Param<List<T>> param)
             => Ensure.Collection.HasItems(param.Value, param.Name, param.OptsFn);
 
-        public static void HasItems<T>(this Param<IList<T>> param)
+        public static void HasItems<T>(this in Param<IList<T>> param)
             => Ensure.Collection.HasItems(param.Value, param.Name, param.OptsFn);
 
-        public static void HasItems<T>(this Param<HashSet<T>> param)
+        public static void HasItems<T>(this in Param<HashSet<T>> param)
             => Ensure.Collection.HasItems(param.Value, param.Name, param.OptsFn);
 
-        public static void HasItems<T>(this Param<ISet<T>> param)
+        public static void HasItems<T>(this in Param<ISet<T>> param)
             => Ensure.Collection.HasItems(param.Value, param.Name, param.OptsFn);
 
-        public static void HasItems<TKey, TValue>(this Param<Dictionary<TKey, TValue>> param)
+        public static void HasItems<TKey, TValue>(this in Param<Dictionary<TKey, TValue>> param)
             => Ensure.Collection.HasItems(param.Value, param.Name, param.OptsFn);
 
-        public static void HasItems<TKey, TValue>(this Param<IDictionary<TKey, TValue>> param)
+        public static void HasItems<TKey, TValue>(this in Param<IDictionary<TKey, TValue>> param)
             => Ensure.Collection.HasItems(param.Value, param.Name, param.OptsFn);
 
-        public static void HasItems<T>(this Param<IReadOnlyCollection<T>> param)
+        public static void HasItems<T>(this in Param<IReadOnlyCollection<T>> param)
             => Ensure.Collection.HasItems(param.Value, param.Name, param.OptsFn);
 
-        public static void HasItems<T>(this Param<IReadOnlyList<T>> param)
+        public static void HasItems<T>(this in Param<IReadOnlyList<T>> param)
             => Ensure.Collection.HasItems(param.Value, param.Name, param.OptsFn);
 
-        public static void SizeIs<T>(this Param<T[]> param, int expected)
+        public static void SizeIs<T>(this in Param<T[]> param, int expected)
             => Ensure.Collection.SizeIs(param.Value, expected, param.Name, param.OptsFn);
 
-        public static void SizeIs<T>(this Param<T[]> param, long expected)
+        public static void SizeIs<T>(this in Param<T[]> param, long expected)
             => Ensure.Collection.SizeIs(param.Value, expected, param.Name, param.OptsFn);
 
-        public static void SizeIs<T>(this Param<T> param, int expected) where T : class, ICollection
+        public static void SizeIs<T>(this in Param<T> param, int expected) where T : class, ICollection
             => Ensure.Collection.SizeIs(param.Value, expected, param.Name, param.OptsFn);
 
-        public static void SizeIs<T>(this Param<T> param, long expected) where T : class, ICollection
+        public static void SizeIs<T>(this in Param<T> param, long expected) where T : class, ICollection
             => Ensure.Collection.SizeIs(param.Value, expected, param.Name, param.OptsFn);
 
-        public static void SizeIs<T>(this Param<ICollection<T>> param, int expected)
+        public static void SizeIs<T>(this in Param<ICollection<T>> param, int expected)
             => Ensure.Collection.SizeIs(param.Value, expected, param.Name, param.OptsFn);
 
-        public static void SizeIs<T>(this Param<ICollection<T>> param, long expected)
+        public static void SizeIs<T>(this in Param<ICollection<T>> param, long expected)
             => Ensure.Collection.SizeIs(param.Value, expected, param.Name, param.OptsFn);
 
-        public static void SizeIs<T>(this Param<IList<T>> param, int expected)
+        public static void SizeIs<T>(this in Param<IList<T>> param, int expected)
             => Ensure.Collection.SizeIs(param.Value, expected, param.Name, param.OptsFn);
 
-        public static void SizeIs<T>(this Param<IList<T>> param, long expected)
+        public static void SizeIs<T>(this in Param<IList<T>> param, long expected)
             => Ensure.Collection.SizeIs(param.Value, expected, param.Name, param.OptsFn);
 
-        public static void SizeIs<TKey, TValue>(this Param<IDictionary<TKey, TValue>> param, int expected)
+        public static void SizeIs<TKey, TValue>(this in Param<IDictionary<TKey, TValue>> param, int expected)
             => Ensure.Collection.SizeIs(param.Value, expected, param.Name, param.OptsFn);
 
-        public static void SizeIs<TKey, TValue>(this Param<IDictionary<TKey, TValue>> param, long expected)
+        public static void SizeIs<TKey, TValue>(this in Param<IDictionary<TKey, TValue>> param, long expected)
             => Ensure.Collection.SizeIs(param.Value, expected, param.Name, param.OptsFn);
 
-        public static void ContainsKey<TKey, TValue>(this Param<IDictionary<TKey, TValue>> param, TKey key)
+        public static void ContainsKey<TKey, TValue>(this in Param<IDictionary<TKey, TValue>> param, TKey key)
             => Ensure.Collection.ContainsKey(param.Value, key, param.Name, param.OptsFn);
 
-        public static void ContainsKey<TKey, TValue>(this Param<Dictionary<TKey, TValue>> param, TKey key)
+        public static void ContainsKey<TKey, TValue>(this in Param<Dictionary<TKey, TValue>> param, TKey key)
             => Ensure.Collection.ContainsKey(param.Value, key, param.Name, param.OptsFn);
 
-        public static void HasAny<T>(this Param<IList<T>> param, Func<T, bool> predicate)
+        public static void HasAny<T>(this in Param<IList<T>> param, Func<T, bool> predicate)
             => Ensure.Collection.HasAny(param.Value, predicate, param.Name, param.OptsFn);
 
-        public static void HasAny<T>(this Param<List<T>> param, Func<T, bool> predicate)
+        public static void HasAny<T>(this in Param<List<T>> param, Func<T, bool> predicate)
             => Ensure.Collection.HasAny(param.Value, predicate, param.Name, param.OptsFn);
 
-        public static void HasAny<T>(this Param<ICollection<T>> param, Func<T, bool> predicate)
+        public static void HasAny<T>(this in Param<ICollection<T>> param, Func<T, bool> predicate)
             => Ensure.Collection.HasAny(param.Value, predicate, param.Name, param.OptsFn);
 
-        public static void HasAny<T>(this Param<Collection<T>> param, Func<T, bool> predicate)
+        public static void HasAny<T>(this in Param<Collection<T>> param, Func<T, bool> predicate)
             => Ensure.Collection.HasAny(param.Value, predicate, param.Name, param.OptsFn);
 
-        public static void HasAny<TKey, TValue>(this Param<IDictionary<TKey, TValue>> param, Func<KeyValuePair<TKey, TValue>, bool> predicate)
+        public static void HasAny<TKey, TValue>(this in Param<IDictionary<TKey, TValue>> param, Func<KeyValuePair<TKey, TValue>, bool> predicate)
             => Ensure.Collection.HasAny(param.Value, predicate, param.Name, param.OptsFn);
 
-        public static void HasAny<TKey, TValue>(this Param<Dictionary<TKey, TValue>> param, Func<KeyValuePair<TKey, TValue>, bool> predicate)
+        public static void HasAny<TKey, TValue>(this in Param<Dictionary<TKey, TValue>> param, Func<KeyValuePair<TKey, TValue>, bool> predicate)
             => Ensure.Collection.HasAny(param.Value, predicate, param.Name, param.OptsFn);
 
-        public static void HasAny<T>(this Param<T[]> param, Func<T, bool> predicate)
+        public static void HasAny<T>(this in Param<T[]> param, Func<T, bool> predicate)
             => Ensure.Collection.HasAny(param.Value, predicate, param.Name, param.OptsFn);
     }
 }

--- a/src/projects/EnsureThat/EnsureThatComparableDateTimeExtensions.cs
+++ b/src/projects/EnsureThat/EnsureThatComparableDateTimeExtensions.cs
@@ -4,25 +4,25 @@ namespace EnsureThat
 {
     public static class EnsureThatComparableDateTimeExtensions
     {
-        public static void Is(this Param<DateTime> param, DateTime expected)
+        public static void Is(this in Param<DateTime> param, DateTime expected)
             => Ensure.Comparable.Is(param.Value, expected, param.Name, param.OptsFn);
 
-        public static void IsNot(this Param<DateTime> param, DateTime expected)
+        public static void IsNot(this in Param<DateTime> param, DateTime expected)
             => Ensure.Comparable.IsNot(param.Value, expected, param.Name, param.OptsFn);
 
-        public static void IsLt(this Param<DateTime> param, DateTime limit)
+        public static void IsLt(this in Param<DateTime> param, DateTime limit)
             => Ensure.Comparable.IsLt(param.Value, limit, param.Name, param.OptsFn);
 
-        public static void IsLte(this Param<DateTime> param, DateTime limit)
+        public static void IsLte(this in Param<DateTime> param, DateTime limit)
             => Ensure.Comparable.IsLte(param.Value, limit, param.Name, param.OptsFn);
 
-        public static void IsGt(this Param<DateTime> param, DateTime limit)
+        public static void IsGt(this in Param<DateTime> param, DateTime limit)
             => Ensure.Comparable.IsGt(param.Value, limit, param.Name, param.OptsFn);
 
-        public static void IsGte(this Param<DateTime> param, DateTime limit)
+        public static void IsGte(this in Param<DateTime> param, DateTime limit)
             => Ensure.Comparable.IsGte(param.Value, limit, param.Name, param.OptsFn);
 
-        public static void IsInRange(this Param<DateTime> param, DateTime min, DateTime max)
+        public static void IsInRange(this in Param<DateTime> param, DateTime min, DateTime max)
             => Ensure.Comparable.IsInRange(param.Value, min, max, param.Name, param.OptsFn);
     }
 }

--- a/src/projects/EnsureThat/EnsureThatComparableDecimalExtensions.cs
+++ b/src/projects/EnsureThat/EnsureThatComparableDecimalExtensions.cs
@@ -2,25 +2,25 @@
 {
     public static class EnsureThatComparableDecimalExtensions
     {
-        public static void Is(this Param<decimal> param, decimal expected)
+        public static void Is(this in Param<decimal> param, decimal expected)
             => Ensure.Comparable.Is(param.Value, expected, param.Name, param.OptsFn);
 
-        public static void IsNot(this Param<decimal> param, decimal expected)
+        public static void IsNot(this in Param<decimal> param, decimal expected)
             => Ensure.Comparable.IsNot(param.Value, expected, param.Name, param.OptsFn);
 
-        public static void IsLt(this Param<decimal> param, decimal limit)
+        public static void IsLt(this in Param<decimal> param, decimal limit)
             => Ensure.Comparable.IsLt(param.Value, limit, param.Name, param.OptsFn);
 
-        public static void IsLte(this Param<decimal> param, decimal limit)
+        public static void IsLte(this in Param<decimal> param, decimal limit)
             => Ensure.Comparable.IsLte(param.Value, limit, param.Name, param.OptsFn);
 
-        public static void IsGt(this Param<decimal> param, decimal limit)
+        public static void IsGt(this in Param<decimal> param, decimal limit)
             => Ensure.Comparable.IsGt(param.Value, limit, param.Name, param.OptsFn);
 
-        public static void IsGte(this Param<decimal> param, decimal limit)
+        public static void IsGte(this in Param<decimal> param, decimal limit)
             => Ensure.Comparable.IsGte(param.Value, limit, param.Name, param.OptsFn);
 
-        public static void IsInRange(this Param<decimal> param, decimal min, decimal max)
+        public static void IsInRange(this in Param<decimal> param, decimal min, decimal max)
             => Ensure.Comparable.IsInRange(param.Value, min, max, param.Name, param.OptsFn);
     }
 }

--- a/src/projects/EnsureThat/EnsureThatComparableDoubleExtensions.cs
+++ b/src/projects/EnsureThat/EnsureThatComparableDoubleExtensions.cs
@@ -2,25 +2,25 @@
 {
     public static class EnsureThatComparableDoubleExtensions
     {
-        public static void Is(this Param<double> param, double expected)
+        public static void Is(this in Param<double> param, double expected)
             => Ensure.Comparable.Is(param.Value, expected, param.Name, param.OptsFn);
 
-        public static void IsNot(this Param<double> param, double expected)
+        public static void IsNot(this in Param<double> param, double expected)
             => Ensure.Comparable.IsNot(param.Value, expected, param.Name, param.OptsFn);
 
-        public static void IsLt(this Param<double> param, double limit)
+        public static void IsLt(this in Param<double> param, double limit)
             => Ensure.Comparable.IsLt(param.Value, limit, param.Name, param.OptsFn);
 
-        public static void IsLte(this Param<double> param, double limit)
+        public static void IsLte(this in Param<double> param, double limit)
             => Ensure.Comparable.IsLte(param.Value, limit, param.Name, param.OptsFn);
 
-        public static void IsGt(this Param<double> param, double limit)
+        public static void IsGt(this in Param<double> param, double limit)
             => Ensure.Comparable.IsGt(param.Value, limit, param.Name, param.OptsFn);
 
-        public static void IsGte(this Param<double> param, double limit)
+        public static void IsGte(this in Param<double> param, double limit)
             => Ensure.Comparable.IsGte(param.Value, limit, param.Name, param.OptsFn);
 
-        public static void IsInRange(this Param<double> param, double min, double max)
+        public static void IsInRange(this in Param<double> param, double min, double max)
             => Ensure.Comparable.IsInRange(param.Value, min, max, param.Name, param.OptsFn);
     }
 }

--- a/src/projects/EnsureThat/EnsureThatComparableExtensions.cs
+++ b/src/projects/EnsureThat/EnsureThatComparableExtensions.cs
@@ -5,46 +5,46 @@ namespace EnsureThat
 {
     public static class EnsureThatComparableExtensions
     {
-        public static void Is<T>(this Param<T> param, T expected) where T : IComparable<T>
+        public static void Is<T>(this in Param<T> param, T expected) where T : IComparable<T>
             => Ensure.Comparable.Is(param.Value, expected, param.Name, param.OptsFn);
 
-        public static void Is<T>(this Param<T> param, T expected, IComparer<T> comparer) where T : IComparable<T>
+        public static void Is<T>(this in Param<T> param, T expected, IComparer<T> comparer) where T : IComparable<T>
             => Ensure.Comparable.Is(param.Value, expected, comparer, param.Name, param.OptsFn);
 
-        public static void IsNot<T>(this Param<T> param, T expected) where T : IComparable<T>
+        public static void IsNot<T>(this in Param<T> param, T expected) where T : IComparable<T>
             => Ensure.Comparable.IsNot(param.Value, expected, param.Name, param.OptsFn);
 
-        public static void IsNot<T>(this Param<T> param, T expected, IComparer<T> comparer) where T : IComparable<T>
+        public static void IsNot<T>(this in Param<T> param, T expected, IComparer<T> comparer) where T : IComparable<T>
             => Ensure.Comparable.IsNot(param.Value, expected, comparer, param.Name, param.OptsFn);
 
-        public static void IsLt<T>(this Param<T> param, T limit) where T : IComparable<T>
+        public static void IsLt<T>(this in Param<T> param, T limit) where T : IComparable<T>
             => Ensure.Comparable.IsLt(param.Value, limit, param.Name, param.OptsFn);
 
-        public static void IsLt<T>(this Param<T> param, T limit, IComparer<T> comparer) where T : IComparable<T>
+        public static void IsLt<T>(this in Param<T> param, T limit, IComparer<T> comparer) where T : IComparable<T>
             => Ensure.Comparable.IsLt(param.Value, limit, comparer, param.Name, param.OptsFn);
 
-        public static void IsLte<T>(this Param<T> param, T limit) where T : IComparable<T>
+        public static void IsLte<T>(this in Param<T> param, T limit) where T : IComparable<T>
             => Ensure.Comparable.IsLte(param.Value, limit, param.Name, param.OptsFn);
 
-        public static void IsLte<T>(this Param<T> param, T limit, IComparer<T> comparer) where T : IComparable<T>
+        public static void IsLte<T>(this in Param<T> param, T limit, IComparer<T> comparer) where T : IComparable<T>
             => Ensure.Comparable.IsLte(param.Value, limit, comparer, param.Name, param.OptsFn);
 
-        public static void IsGt<T>(this Param<T> param, T limit) where T : IComparable<T>
+        public static void IsGt<T>(this in Param<T> param, T limit) where T : IComparable<T>
             => Ensure.Comparable.IsGt(param.Value, limit, param.Name, param.OptsFn);
 
-        public static void IsGt<T>(this Param<T> param, T limit, IComparer<T> comparer) where T : IComparable<T>
+        public static void IsGt<T>(this in Param<T> param, T limit, IComparer<T> comparer) where T : IComparable<T>
             => Ensure.Comparable.IsGt(param.Value, limit, comparer, param.Name, param.OptsFn);
 
-        public static void IsGte<T>(this Param<T> param, T limit) where T : IComparable<T>
+        public static void IsGte<T>(this in Param<T> param, T limit) where T : IComparable<T>
             => Ensure.Comparable.IsGte(param.Value, limit, param.Name, param.OptsFn);
 
-        public static void IsGte<T>(this Param<T> param, T limit, IComparer<T> comparer) where T : IComparable<T>
+        public static void IsGte<T>(this in Param<T> param, T limit, IComparer<T> comparer) where T : IComparable<T>
             => Ensure.Comparable.IsGte(param.Value, limit, comparer, param.Name, param.OptsFn);
 
-        public static void IsInRange<T>(this Param<T> param, T min, T max) where T : IComparable<T>
+        public static void IsInRange<T>(this in Param<T> param, T min, T max) where T : IComparable<T>
             => Ensure.Comparable.IsInRange(param.Value, min, max, param.Name, param.OptsFn);
 
-        public static void IsInRange<T>(this Param<T> param, T min, T max, IComparer<T> comparer) where T : IComparable<T>
+        public static void IsInRange<T>(this in Param<T> param, T min, T max, IComparer<T> comparer) where T : IComparable<T>
             => Ensure.Comparable.IsInRange(param.Value, min, max, comparer, param.Name, param.OptsFn);
     }
 }

--- a/src/projects/EnsureThat/EnsureThatComparableIntExtensions.cs
+++ b/src/projects/EnsureThat/EnsureThatComparableIntExtensions.cs
@@ -2,25 +2,25 @@
 {
     public static class EnsureThatComparableIntExtensions
     {
-        public static void Is(this Param<int> param, int expected)
+        public static void Is(this in Param<int> param, int expected)
             => Ensure.Comparable.Is(param.Value, expected, param.Name, param.OptsFn);
 
-        public static void IsNot(this Param<int> param, int expected)
+        public static void IsNot(this in Param<int> param, int expected)
             => Ensure.Comparable.IsNot(param.Value, expected, param.Name, param.OptsFn);
 
-        public static void IsLt(this Param<int> param, int limit)
+        public static void IsLt(this in Param<int> param, int limit)
             => Ensure.Comparable.IsLt(param.Value, limit, param.Name, param.OptsFn);
 
-        public static void IsLte(this Param<int> param, int limit)
+        public static void IsLte(this in Param<int> param, int limit)
             => Ensure.Comparable.IsLte(param.Value, limit, param.Name, param.OptsFn);
 
-        public static void IsGt(this Param<int> param, int limit)
+        public static void IsGt(this in Param<int> param, int limit)
             => Ensure.Comparable.IsGt(param.Value, limit, param.Name, param.OptsFn);
 
-        public static void IsGte(this Param<int> param, int limit)
+        public static void IsGte(this in Param<int> param, int limit)
             => Ensure.Comparable.IsGte(param.Value, limit, param.Name, param.OptsFn);
 
-        public static void IsInRange(this Param<int> param, int min, int max)
+        public static void IsInRange(this in Param<int> param, int min, int max)
             => Ensure.Comparable.IsInRange(param.Value, min, max, param.Name, param.OptsFn);
     }
 }

--- a/src/projects/EnsureThat/EnsureThatComparableLongExtensions.cs
+++ b/src/projects/EnsureThat/EnsureThatComparableLongExtensions.cs
@@ -2,25 +2,25 @@
 {
     public static class EnsureThatComparableLongExtensions
     {
-        public static void Is(this Param<long> param, long expected)
+        public static void Is(this in Param<long> param, long expected)
             => Ensure.Comparable.Is(param.Value, expected, param.Name, param.OptsFn);
 
-        public static void IsNot(this Param<long> param, long expected)
+        public static void IsNot(this in Param<long> param, long expected)
             => Ensure.Comparable.IsNot(param.Value, expected, param.Name, param.OptsFn);
 
-        public static void IsLt(this Param<long> param, long limit)
+        public static void IsLt(this in Param<long> param, long limit)
             => Ensure.Comparable.IsLt(param.Value, limit, param.Name, param.OptsFn);
 
-        public static void IsLte(this Param<long> param, long limit)
+        public static void IsLte(this in Param<long> param, long limit)
             => Ensure.Comparable.IsLte(param.Value, limit, param.Name, param.OptsFn);
 
-        public static void IsGt(this Param<long> param, long limit)
+        public static void IsGt(this in Param<long> param, long limit)
             => Ensure.Comparable.IsGt(param.Value, limit, param.Name, param.OptsFn);
 
-        public static void IsGte(this Param<long> param, long limit)
+        public static void IsGte(this in Param<long> param, long limit)
             => Ensure.Comparable.IsGte(param.Value, limit, param.Name, param.OptsFn);
 
-        public static void IsInRange(this Param<long> param, long min, long max)
+        public static void IsInRange(this in Param<long> param, long min, long max)
             => Ensure.Comparable.IsInRange(param.Value, min, max, param.Name, param.OptsFn);
     }
 }

--- a/src/projects/EnsureThat/EnsureThatObjectExtensions.cs
+++ b/src/projects/EnsureThat/EnsureThatObjectExtensions.cs
@@ -2,7 +2,7 @@
 {
     public static class EnsureThatObjectExtensions
     {
-        public static void IsNotNull<T>(this Param<T> param) where T : class
+        public static void IsNotNull<T>(this in Param<T> param) where T : class
             => Ensure.Any.IsNotNull(param.Value, param.Name, param.OptsFn);
     }
 }

--- a/src/projects/EnsureThat/EnsureThatStringExtensions.cs
+++ b/src/projects/EnsureThat/EnsureThatStringExtensions.cs
@@ -6,78 +6,78 @@ namespace EnsureThat
 {
     public static class EnsureThatStringExtensions
     {
-        public static void IsNotNull(this StringParam param)
+        public static void IsNotNull(this in StringParam param)
             => Ensure.String.IsNotNull(param.Value, param.Name, param.OptsFn);
 
-        public static void IsNotNullOrWhiteSpace(this StringParam param)
+        public static void IsNotNullOrWhiteSpace(this in StringParam param)
             => Ensure.String.IsNotNullOrWhiteSpace(param.Value, param.Name, param.OptsFn);
 
-        public static void IsNotNullOrEmpty(this StringParam param)
+        public static void IsNotNullOrEmpty(this in StringParam param)
             => Ensure.String.IsNotNullOrEmpty(param.Value, param.Name, param.OptsFn);
 
-        public static void IsNotEmptyOrWhitespace(this StringParam param)
+        public static void IsNotEmptyOrWhitespace(this in StringParam param)
             => Ensure.String.IsNotEmptyOrWhitespace(param.Value, param.Name, param.OptsFn);
-        public static void IsNotEmpty(this StringParam param)
+        public static void IsNotEmpty(this in StringParam param)
             => Ensure.String.IsNotEmpty(param.Value, param.Name, param.OptsFn);
 
-        public static void HasLengthBetween(this StringParam param, int minLength, int maxLength)
+        public static void HasLengthBetween(this in StringParam param, int minLength, int maxLength)
             => Ensure.String.HasLengthBetween(param.Value, minLength, maxLength, param.Name, param.OptsFn);
 
-        public static void Matches(this StringParam param, [RegexPattern] string match)
+        public static void Matches(this in StringParam param, [RegexPattern] string match)
             => Ensure.String.Matches(param.Value, match, param.Name, param.OptsFn);
 
-        public static void Matches(this StringParam param, [NotNull] Regex match)
+        public static void Matches(this in StringParam param, [NotNull] Regex match)
             => Ensure.String.Matches(param.Value, match, param.Name, param.OptsFn);
 
-        public static void SizeIs(this StringParam param, int expected)
+        public static void SizeIs(this in StringParam param, int expected)
             => Ensure.String.SizeIs(param.Value, expected, param.Name, param.OptsFn);
 
-        public static void Is(this StringParam param, string expected)
+        public static void Is(this in StringParam param, string expected)
             => Ensure.String.Is(param.Value, expected, param.Name, param.OptsFn);
 
-        public static void IsEqualTo(this StringParam param, string expected)
+        public static void IsEqualTo(this in StringParam param, string expected)
             => Ensure.String.IsEqualTo(param.Value, expected, param.Name, param.OptsFn);
 
-        public static void Is(this StringParam param, string expected, StringComparison comparison)
+        public static void Is(this in StringParam param, string expected, StringComparison comparison)
             => Ensure.String.Is(param.Value, expected, comparison, param.Name, param.OptsFn);
 
-        public static void IsEqualTo(this StringParam param, string expected, StringComparison comparison)
+        public static void IsEqualTo(this in StringParam param, string expected, StringComparison comparison)
             => Ensure.String.IsEqualTo(param.Value, expected, comparison, param.Name, param.OptsFn);
 
-        public static void IsNot(this StringParam param, string notExpected)
+        public static void IsNot(this in StringParam param, string notExpected)
             => Ensure.String.IsNot(param.Value, notExpected, param.Name, param.OptsFn);
 
-        public static void IsNotEqualTo(this StringParam param, string notExpected)
+        public static void IsNotEqualTo(this in StringParam param, string notExpected)
             => Ensure.String.IsNotEqualTo(param.Value, notExpected, param.Name, param.OptsFn);
 
-        public static void IsNot(this StringParam param, string notExpected, StringComparison comparison)
+        public static void IsNot(this in StringParam param, string notExpected, StringComparison comparison)
             => Ensure.String.IsNot(param.Value, notExpected, comparison, param.Name, param.OptsFn);
 
-        public static void IsNotEqualTo(this StringParam param, string notExpected, StringComparison comparison)
+        public static void IsNotEqualTo(this in StringParam param, string notExpected, StringComparison comparison)
             => Ensure.String.IsNotEqualTo(param.Value, notExpected, comparison, param.Name, param.OptsFn);
 
-        public static void IsGuid(this StringParam param)
+        public static void IsGuid(this in StringParam param)
             => Ensure.String.IsGuid(param.Value, param.Name, param.OptsFn);
 
-        public static void StartsWith(this StringParam param, [NotNull] string expectedStartsWith)
+        public static void StartsWith(this in StringParam param, [NotNull] string expectedStartsWith)
             => Ensure.String.StartsWith(param.Value, expectedStartsWith, param.Name, param.OptsFn);
 
-        public static void StartsWith(this StringParam param, [NotNull] string expectedStartsWith, StringComparison comparison)
+        public static void StartsWith(this in StringParam param, [NotNull] string expectedStartsWith, StringComparison comparison)
             => Ensure.String.StartsWith(param.Value, expectedStartsWith, comparison, param.Name, param.OptsFn);
 
-        public static void IsLt(this StringParam param, string limit, StringComparison comparison)
+        public static void IsLt(this in StringParam param, string limit, StringComparison comparison)
             => Ensure.String.IsLt(param.Value, limit, comparison, param.Name, param.OptsFn);
 
-        public static void IsLte(this StringParam param, string limit, StringComparison comparison)
+        public static void IsLte(this in StringParam param, string limit, StringComparison comparison)
             => Ensure.String.IsLte(param.Value, limit, comparison, param.Name, param.OptsFn);
 
-        public static void IsGt(this StringParam param, string limit, StringComparison comparison)
+        public static void IsGt(this in StringParam param, string limit, StringComparison comparison)
             => Ensure.String.IsGt(param.Value, limit, comparison, param.Name, param.OptsFn);
 
-        public static void IsGte(this StringParam param, string limit, StringComparison comparison)
+        public static void IsGte(this in StringParam param, string limit, StringComparison comparison)
             => Ensure.String.IsGte(param.Value, limit, comparison, param.Name, param.OptsFn);
 
-        public static void IsInRange(this StringParam param, string min, string max, StringComparison comparison)
+        public static void IsInRange(this in StringParam param, string min, string max, StringComparison comparison)
             => Ensure.String.IsInRange(param.Value, min, max, comparison, param.Name, param.OptsFn);
     }
 }

--- a/src/projects/EnsureThat/EnsureThatTypeExtensions.cs
+++ b/src/projects/EnsureThat/EnsureThatTypeExtensions.cs
@@ -5,40 +5,40 @@ namespace EnsureThat
 {
     public static class EnsureThatTypeExtensions
     {
-        public static void IsInt(this TypeParam param)
+        public static void IsInt(this in TypeParam param)
             => Ensure.Type.IsInt(param.Type, param.Name, param.OptsFn);
 
-        public static void IsShort(this TypeParam param)
+        public static void IsShort(this in TypeParam param)
             => Ensure.Type.IsShort(param.Type, param.Name, param.OptsFn);
 
-        public static void IsDecimal(this TypeParam param)
+        public static void IsDecimal(this in TypeParam param)
             => Ensure.Type.IsDecimal(param.Type, param.Name, param.OptsFn);
 
-        public static void IsDouble(this TypeParam param)
+        public static void IsDouble(this in TypeParam param)
             => Ensure.Type.IsDouble(param.Type, param.Name, param.OptsFn);
 
-        public static void IsFloat(this TypeParam param)
+        public static void IsFloat(this in TypeParam param)
             => Ensure.Type.IsFloat(param.Type, param.Name, param.OptsFn);
 
-        public static void IsBool(this TypeParam param)
+        public static void IsBool(this in TypeParam param)
             => Ensure.Type.IsBool(param.Type, param.Name, param.OptsFn);
 
-        public static void IsDateTime(this TypeParam param)
+        public static void IsDateTime(this in TypeParam param)
             => Ensure.Type.IsDateTime(param.Type, param.Name, param.OptsFn);
 
-        public static void IsString(this TypeParam param)
+        public static void IsString(this in TypeParam param)
             => Ensure.Type.IsString(param.Type, param.Name, param.OptsFn);
 
-        public static void IsOfType(this TypeParam param, [NotNull] Type expectedType)
+        public static void IsOfType(this in TypeParam param, [NotNull] Type expectedType)
             => Ensure.Type.IsOfType(param.Type, expectedType, param.Name, param.OptsFn);
 
-        public static void IsNotOfType(this TypeParam param, Type expectedType)
+        public static void IsNotOfType(this in TypeParam param, Type expectedType)
             => Ensure.Type.IsNotOfType(param.Type, expectedType, param.Name, param.OptsFn);
 
-        public static void IsClass<T>(this Param<T> param)
+        public static void IsClass<T>(this in Param<T> param)
             => Ensure.Type.IsClass(param.Value, param.Name, param.OptsFn);
 
-        public static void IsClass(this TypeParam param)
+        public static void IsClass(this in TypeParam param)
             => Ensure.Type.IsClass(param.Type, param.Name, param.OptsFn);
     }
 }

--- a/src/projects/EnsureThat/EnsureThatValueTypeExtensions.cs
+++ b/src/projects/EnsureThat/EnsureThatValueTypeExtensions.cs
@@ -4,19 +4,19 @@ namespace EnsureThat
 {
     public static class EnsureThatValueTypeExtensions
     {
-        public static void IsTrue(this Param<bool> param)
+        public static void IsTrue(this in Param<bool> param)
             => Ensure.Bool.IsTrue(param.Value, param.Name, param.OptsFn);
 
-        public static void IsFalse(this Param<bool> param)
+        public static void IsFalse(this in Param<bool> param)
             => Ensure.Bool.IsFalse(param.Value, param.Name, param.OptsFn);
 
-        public static void IsNotDefault<T>(this Param<T> param) where T : struct
+        public static void IsNotDefault<T>(this in Param<T> param) where T : struct
             => Ensure.Any.IsNotDefault(param.Value, param.Name, param.OptsFn);
 
-        public static void IsNotNull<T>(this Param<T?> param) where T : struct
+        public static void IsNotNull<T>(this in Param<T?> param) where T : struct
             => Ensure.Any.IsNotNull(param.Value, param.Name, param.OptsFn);
 
-        public static void IsNotEmpty(this Param<Guid> param)
+        public static void IsNotEmpty(this in Param<Guid> param)
             => Ensure.Guid.IsNotEmpty(param.Value, param.Name, param.OptsFn);
     }
 }

--- a/src/projects/EnsureThat/Param.cs
+++ b/src/projects/EnsureThat/Param.cs
@@ -3,7 +3,7 @@ using JetBrains.Annotations;
 
 namespace EnsureThat
 {
-    public struct Param<T>
+    public readonly struct Param<T>
     {
         public readonly string Name;
         public readonly T Value;
@@ -17,7 +17,7 @@ namespace EnsureThat
         }
     }
 
-    public struct StringParam
+    public readonly struct StringParam
     {
         public readonly string Name;
         public readonly string Value;
@@ -31,7 +31,7 @@ namespace EnsureThat
         }
     }
 
-    public struct TypeParam
+    public readonly struct TypeParam
     {
         public readonly string Name;
         [NotNull]


### PR DESCRIPTION
https://devblogs.microsoft.com/premier-developer/the-in-modifier-and-the-readonly-structs-in-c/

TL;DR right now this statement:
Ensure.That(blah, blah).IsNotNull() creates the Param struct, but then the call to IsNotNull will actually COPY the Param struct to ensure that writes inside IsNotNull do not affect the object we were passing in (even though we never capture it -- optimization the compiler doesn't do yet). Using `in` and `readonly` tell the compiler there's no need to do this.

Disclaimer: it built locally, but slightly relying on the PR automation to validate that the feature is available in our configuration :)