### PR TITLE
Fixes #86 - Implement Is(Not)AssignableToType

### DIFF
--- a/src/projects/EnsureThat/Enforcers/TypeArg.cs
+++ b/src/projects/EnsureThat/Enforcers/TypeArg.cs
@@ -162,6 +162,70 @@ namespace EnsureThat.Enforcers
 
         [NotNull]
         [ContractAnnotation("param:null => halt")]
+        public T IsAssignableToType<T>([ValidatedNotNull]T param, Type expectedType, [InvokerParameterName] string paramName = null, OptsFn optsFn = null) where T : class
+        {
+            Ensure.Any.IsNotNull(param, paramName, optsFn);
+
+            IsAssignableToType(param.GetType(), expectedType, paramName, optsFn);
+
+            return param;
+        }
+
+        [NotNull]
+        [ContractAnnotation("param:null => halt")]
+        public Type IsAssignableToType([ValidatedNotNull]Type param, Type expectedType, [InvokerParameterName] string paramName = null, OptsFn optsFn = null)
+        {
+            Ensure.Any.IsNotNull(param, paramName, optsFn);
+            Ensure.Any.IsNotNull(expectedType, nameof(expectedType));
+
+#if NETSTANDARD1_1
+	        // According to: https://devblogs.microsoft.com/dotnet/porting-to-net-core/.
+	        if (!expectedType.GetTypeInfo().IsAssignableFrom(param.GetTypeInfo()))
+#else
+            if (!expectedType.IsAssignableFrom(param))
+#endif
+                throw Ensure.ExceptionFactory.ArgumentException(
+                    string.Format(ExceptionMessages.Types_IsAssignableToType_Failed, expectedType.FullName, param.FullName),
+                    paramName,
+                    optsFn);
+
+            return param;
+        }
+
+        [NotNull]
+        [ContractAnnotation("param:null => halt")]
+        public T IsNotAssignableToType<T>([ValidatedNotNull]T param, Type nonExpectedType, [InvokerParameterName] string paramName = null, OptsFn optsFn = null) where T : class
+        {
+            Ensure.Any.IsNotNull(param, paramName, optsFn);
+
+            IsNotAssignableToType(param.GetType(), nonExpectedType, paramName, optsFn);
+
+            return param;
+        }
+
+        [NotNull]
+        [ContractAnnotation("param:null => halt")]
+        public Type IsNotAssignableToType([ValidatedNotNull]Type param, Type nonExpectedType, [InvokerParameterName] string paramName = null, OptsFn optsFn = null)
+        {
+            Ensure.Any.IsNotNull(param, paramName, optsFn);
+            Ensure.Any.IsNotNull(nonExpectedType, nameof(nonExpectedType));
+
+#if NETSTANDARD1_1
+            // According to: https://devblogs.microsoft.com/dotnet/porting-to-net-core/.
+	        if (nonExpectedType.GetTypeInfo().IsAssignableFrom(param.GetTypeInfo()))
+#else
+            if (nonExpectedType.IsAssignableFrom(param))
+#endif
+                throw Ensure.ExceptionFactory.ArgumentException(
+                    string.Format(ExceptionMessages.Types_IsNotAssignableToType_Failed, nonExpectedType.FullName),
+                    paramName,
+                    optsFn);
+
+            return param;
+        }
+
+        [NotNull]
+        [ContractAnnotation("param:null => halt")]
         public T IsClass<T>([ValidatedNotNull]T param, [InvokerParameterName] string paramName = null, OptsFn optsFn = null)
         {
             if (param == null)

--- a/src/projects/EnsureThat/EnsureArg.Types.cs
+++ b/src/projects/EnsureThat/EnsureArg.Types.cs
@@ -108,6 +108,26 @@ namespace EnsureThat
 
         [NotNull]
         [ContractAnnotation("param:null => halt")]
+        public static object IsAssignableToType([ValidatedNotNull] object param, Type expectedType, [InvokerParameterName] string paramName = null, OptsFn optsFn = null)
+	        => Ensure.Type.IsAssignableToType(param, expectedType, paramName, optsFn);
+
+        [NotNull]
+        [ContractAnnotation("param:null => halt")]
+        public static Type IsAssignableToType([ValidatedNotNull]Type param, Type expectedType, [InvokerParameterName] string paramName = null, OptsFn optsFn = null)
+	        => Ensure.Type.IsAssignableToType(param, expectedType, paramName, optsFn);
+
+        [NotNull]
+        [ContractAnnotation("param:null => halt")]
+        public static object IsNotAssignableToType([ValidatedNotNull]object param, Type nonExpectedType, [InvokerParameterName] string paramName = null, OptsFn optsFn = null)
+	        => Ensure.Type.IsNotAssignableToType(param, nonExpectedType, paramName, optsFn);
+
+        [NotNull]
+        [ContractAnnotation("param:null => halt")]
+        public static Type IsNotAssignableToType([ValidatedNotNull]Type param, Type nonExpectedType, [InvokerParameterName] string paramName = null, OptsFn optsFn = null)
+	        => Ensure.Type.IsNotAssignableToType(param, nonExpectedType, paramName, optsFn);
+
+        [NotNull]
+        [ContractAnnotation("param:null => halt")]
         public static object IsClass([ValidatedNotNull]object param, [InvokerParameterName] string paramName = null, OptsFn optsFn = null)
             => Ensure.Type.IsClass(param, paramName, optsFn);
 

--- a/src/projects/EnsureThat/EnsureThatTypeExtensions.cs
+++ b/src/projects/EnsureThat/EnsureThatTypeExtensions.cs
@@ -35,6 +35,12 @@ namespace EnsureThat
         public static void IsNotOfType(this in TypeParam param, Type expectedType)
             => Ensure.Type.IsNotOfType(param.Type, expectedType, param.Name, param.OptsFn);
 
+        public static void IsAssignableToType(this in TypeParam param, [NotNull] Type expectedType)
+	        => Ensure.Type.IsAssignableToType(param.Type, expectedType, param.Name, param.OptsFn);
+
+        public static void IsNotAssignableToType(this in TypeParam param, Type expectedType)
+	        => Ensure.Type.IsNotAssignableToType(param.Type, expectedType, param.Name, param.OptsFn);
+
         public static void IsClass<T>(this in Param<T> param)
             => Ensure.Type.IsClass(param.Value, param.Name, param.OptsFn);
 

--- a/src/projects/EnsureThat/ExceptionMessages.cs
+++ b/src/projects/EnsureThat/ExceptionMessages.cs
@@ -40,6 +40,8 @@
 
         public static string Types_IsOfType_Failed { get; } = "The param is not of expected type. Expected: '{0}'. Got: '{1}'.";
         public static string Types_IsNotOfType_Failed { get; } = "The param was expected to not be of the type: '{0}'. But it was.";
+        public static string Types_IsAssignableToType_Failed { get; } = "The param is not assignable to the expected type. Expected: '{0}'. Got: '{1}'.";
+        public static string Types_IsNotAssignableToType_Failed { get; } = "The param was expected to not be assignable to the type: '{0}'. But it was.";
         public static string Types_IsClass_Failed_Null { get; } = "The param was expected to be a class, but was NULL.";
         public static string Types_IsClass_Failed { get; } = "The param was expected to be a class, but was type of: '{0}'.";
 

--- a/src/tests/UnitTests/EnsureTypeParamTests.cs
+++ b/src/tests/UnitTests/EnsureTypeParamTests.cs
@@ -10,9 +10,13 @@ namespace UnitTests
 
         private class NonBogus { }
 
+        private class AssignableToNonBogus : NonBogus { }
+
         private static readonly Type BogusType = typeof(Bogus);
 
         private static readonly Type NonBogusType = typeof(NonBogus);
+
+        private static readonly Type AssignableToNonBogusType = typeof(AssignableToNonBogus);
 
         [Fact]
         public void IsOfType_WhenNotTypeOf_ThrowsArgumentException() => AssertIsOfTypeScenario(
@@ -51,6 +55,56 @@ namespace UnitTests
             () => EnsureArg.IsNotOfType(new Bogus(), NonBogusType, ParamName),
             () => Ensure.ThatType(typeof(Bogus), ParamName).IsNotOfType(NonBogusType),
             () => Ensure.ThatTypeFor(new Bogus(), ParamName).IsNotOfType(NonBogusType));
+
+        [Fact]
+        public void IsAssignableToType_WhenNotAssignableToType_ThrowsArgumentException() => AssertIsAssignableToTypeScenario(
+            NonBogusType, BogusType,
+            () => Ensure.Type.IsAssignableToType(typeof(Bogus), NonBogusType, ParamName),
+            () => Ensure.Type.IsAssignableToType(new Bogus(), NonBogusType, ParamName),
+            () => EnsureArg.IsAssignableToType(typeof(Bogus), NonBogusType, ParamName),
+            () => EnsureArg.IsAssignableToType(new Bogus(), NonBogusType, ParamName),
+            () => Ensure.ThatType(typeof(Bogus), ParamName).IsAssignableToType(NonBogusType),
+            () => Ensure.ThatTypeFor(new Bogus(), ParamName).IsAssignableToType(NonBogusType));
+
+        [Fact]
+        public void IsAssignableToType_WhenAssignableToType_It_should_not_throw() => ShouldNotThrow(
+            () => Ensure.Type.IsAssignableToType(NonBogusType, NonBogusType, ParamName),
+            () => Ensure.Type.IsAssignableToType(new NonBogus(), NonBogusType, ParamName),
+            () => EnsureArg.IsAssignableToType(NonBogusType, NonBogusType, ParamName),
+            () => EnsureArg.IsAssignableToType(new NonBogus(), NonBogusType, ParamName),
+            () => Ensure.ThatType(typeof(NonBogus), ParamName).IsAssignableToType(NonBogusType),
+            () => Ensure.ThatTypeFor(new NonBogus(), ParamName).IsAssignableToType(NonBogusType),
+            () => Ensure.Type.IsAssignableToType(AssignableToNonBogusType, NonBogusType, ParamName),
+            () => Ensure.Type.IsAssignableToType(new AssignableToNonBogus(), NonBogusType, ParamName),
+            () => EnsureArg.IsAssignableToType(AssignableToNonBogusType, NonBogusType, ParamName),
+            () => EnsureArg.IsAssignableToType(new AssignableToNonBogus(), NonBogusType, ParamName),
+            () => Ensure.ThatType(typeof(AssignableToNonBogus), ParamName).IsAssignableToType(NonBogusType),
+            () => Ensure.ThatTypeFor(new AssignableToNonBogus(), ParamName).IsAssignableToType(NonBogusType));
+
+        [Fact]
+        public void IsNotAssignableToType_WhenAssignableToType_ThrowsArgumentException() => ShouldThrow<ArgumentException>(
+            string.Format(ExceptionMessages.Types_IsNotAssignableToType_Failed, NonBogusType),
+            () => Ensure.Type.IsNotAssignableToType(typeof(NonBogus), NonBogusType, ParamName),
+            () => Ensure.Type.IsNotAssignableToType(new NonBogus(), NonBogusType, ParamName),
+            () => EnsureArg.IsNotAssignableToType(typeof(NonBogus), NonBogusType, ParamName),
+            () => EnsureArg.IsNotAssignableToType(new NonBogus(), NonBogusType, ParamName),
+            () => Ensure.ThatType(typeof(NonBogus), ParamName).IsNotAssignableToType(NonBogusType),
+            () => Ensure.ThatTypeFor(new NonBogus(), ParamName).IsNotAssignableToType(NonBogusType),
+            () => Ensure.Type.IsNotAssignableToType(typeof(AssignableToNonBogus), NonBogusType, ParamName),
+            () => Ensure.Type.IsNotAssignableToType(new AssignableToNonBogus(), NonBogusType, ParamName),
+            () => EnsureArg.IsNotAssignableToType(typeof(AssignableToNonBogus), NonBogusType, ParamName),
+            () => EnsureArg.IsNotAssignableToType(new AssignableToNonBogus(), NonBogusType, ParamName),
+            () => Ensure.ThatType(typeof(AssignableToNonBogus), ParamName).IsNotAssignableToType(NonBogusType),
+            () => Ensure.ThatTypeFor(new AssignableToNonBogus(), ParamName).IsNotAssignableToType(NonBogusType));
+
+        [Fact]
+        public void IsNotAssignableToType_WhenNotAssignableToType_It_should_not_throw() => ShouldNotThrow(
+            () => Ensure.Type.IsNotAssignableToType(BogusType, NonBogusType, ParamName),
+            () => Ensure.Type.IsNotAssignableToType(new Bogus(), NonBogusType, ParamName),
+            () => EnsureArg.IsNotAssignableToType(BogusType, NonBogusType, ParamName),
+            () => EnsureArg.IsNotAssignableToType(new Bogus(), NonBogusType, ParamName),
+            () => Ensure.ThatType(typeof(Bogus), ParamName).IsNotAssignableToType(NonBogusType),
+            () => Ensure.ThatTypeFor(new Bogus(), ParamName).IsNotAssignableToType(NonBogusType));
 
         [Fact]
         public void IsInt_WhenNotTypeOf_ThrowsArgumentException() => AssertIsOfTypeScenario(
@@ -257,6 +311,9 @@ namespace UnitTests
 
         private static void AssertIsOfTypeScenario(Type expected, Type actual, params Action[] actions)
             => ShouldThrow<ArgumentException>(string.Format(ExceptionMessages.Types_IsOfType_Failed, expected.FullName, actual.FullName), actions);
+
+        private static void AssertIsAssignableToTypeScenario(Type expected, Type actual, params Action[] actions)
+	        => ShouldThrow<ArgumentException>(string.Format(ExceptionMessages.Types_IsAssignableToType_Failed, expected.FullName, actual.FullName), actions);
 
         private static void AssertIsNotClass(Type type, params Action[] actions)
             => ShouldThrow<ArgumentException>(string.Format(ExceptionMessages.Types_IsClass_Failed, type.FullName), actions);


### PR DESCRIPTION
This PR should fix #86. Instead of extending Is(Not)OfType I implement Is(Not)AssignableToType instead, like mentioned in the issue. Also, added a couple of unit tests to cover the new functionality.