### PR TITLE
Add `IsAllLettersOrDigits` method for strings

### DIFF
--- a/src/projects/EnsureThat/Enforcers/StringArg.cs
+++ b/src/projects/EnsureThat/Enforcers/StringArg.cs
@@ -277,11 +277,12 @@ namespace EnsureThat.Enforcers
         {
             Ensure.Any.IsNotNull(value, paramName, optsFn);
 
-            if (!value.ToCharArray().All(char.IsLetterOrDigit))
-                throw Ensure.ExceptionFactory.ArgumentException(
-                    string.Format(ExceptionMessages.Strings_IsAllLettersOrDigits_Failed, value),
-                    paramName,
-                    optsFn);
+            for (var i = 0; i < value.Length; i++)
+                if (!char.IsLetterOrDigit(value[i]))
+                    throw Ensure.ExceptionFactory.ArgumentException(
+                        string.Format(ExceptionMessages.Strings_IsAllLettersOrDigits_Failed, value),
+                        paramName,
+                        optsFn);
 
             return value;
         }

--- a/src/projects/EnsureThat/Enforcers/StringArg.cs
+++ b/src/projects/EnsureThat/Enforcers/StringArg.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Text.RegularExpressions;
 using EnsureThat.Annotations;
 using JetBrains.Annotations;
@@ -266,6 +267,19 @@ namespace EnsureThat.Enforcers
             if (StringIsGt(value, max, comparison))
                 throw Ensure.ExceptionFactory.ArgumentOutOfRangeException(
                     string.Format(ExceptionMessages.Comp_IsNotInRange_ToHigh, value, max), paramName, value, optsFn);
+
+            return value;
+        }
+
+        public string IsAllLettersOrDigits([ValidatedNotNull] string value, [InvokerParameterName] string paramName = null, OptsFn optsFn = null)
+        {
+            Ensure.Any.IsNotNull(value, paramName, optsFn);
+
+            if (!value.ToCharArray().All(char.IsLetterOrDigit))
+                throw Ensure.ExceptionFactory.ArgumentException(
+                    string.Format(ExceptionMessages.Strings_IsAllLettersOrDigits_Failed, value),
+                    paramName,
+                    optsFn);
 
             return value;
         }

--- a/src/projects/EnsureThat/Enforcers/StringArg.cs
+++ b/src/projects/EnsureThat/Enforcers/StringArg.cs
@@ -271,6 +271,8 @@ namespace EnsureThat.Enforcers
             return value;
         }
 
+        [NotNull]
+        [ContractAnnotation("value:null => halt")]
         public string IsAllLettersOrDigits([ValidatedNotNull] string value, [InvokerParameterName] string paramName = null, OptsFn optsFn = null)
         {
             Ensure.Any.IsNotNull(value, paramName, optsFn);

--- a/src/projects/EnsureThat/EnsureArg.Strings.cs
+++ b/src/projects/EnsureThat/EnsureArg.Strings.cs
@@ -86,6 +86,7 @@ namespace EnsureThat
             => Ensure.String.StartsWith(value, expectedStartsWith, comparisonType, paramName, optsFn);
 
         [NotNull]
+        [ContractAnnotation("value:null => halt")]
         public static string IsAllLettersOrDigits([ValidatedNotNull] string value, [InvokerParameterName] string paramName = null, OptsFn optsFn = null)
             => Ensure.String.IsAllLettersOrDigits(value, paramName, optsFn);
     }

--- a/src/projects/EnsureThat/EnsureArg.Strings.cs
+++ b/src/projects/EnsureThat/EnsureArg.Strings.cs
@@ -84,5 +84,9 @@ namespace EnsureThat
         [ContractAnnotation("value:null => halt")]
         public static string StartsWith([ValidatedNotNull] string value, [NotNull] string expectedStartsWith, StringComparison comparisonType, [InvokerParameterName] string paramName = null, OptsFn optsFn = null)
             => Ensure.String.StartsWith(value, expectedStartsWith, comparisonType, paramName, optsFn);
+
+        [NotNull]
+        public static string IsAllLettersOrDigits([ValidatedNotNull] string value, [InvokerParameterName] string paramName = null, OptsFn optsFn = null)
+            => Ensure.String.IsAllLettersOrDigits(value, paramName, optsFn);
     }
 }

--- a/src/projects/EnsureThat/EnsureThatStringExtensions.cs
+++ b/src/projects/EnsureThat/EnsureThatStringExtensions.cs
@@ -80,5 +80,8 @@ namespace EnsureThat
 
         public static void IsInRange(this in StringParam param, string min, string max, StringComparison comparison)
             => Ensure.String.IsInRange(param.Value, min, max, comparison, param.Name, param.OptsFn);
+
+        public static void IsAllLettersOrDigits(this in StringParam param)
+            => Ensure.String.IsAllLettersOrDigits(param.Value, param.Name, param.OptsFn);
     }
 }

--- a/src/projects/EnsureThat/ExceptionMessages.cs
+++ b/src/projects/EnsureThat/ExceptionMessages.cs
@@ -37,7 +37,7 @@
         public static string Strings_IsNotEmpty_Failed { get; } = "Empty String is not allowed.";
         public static string Strings_IsGuid_Failed { get; } = "Value '{0}' is not a valid GUID.";
         public static string Strings_StartsWith_Failed { get; } = "Value '{0}' is expected to start with '{1}' but does not.";
-
+        public static string Strings_IsAllLettersOrDigits_Failed { get; } = "Expected '{0} to contain only letters or digits but does not.";
         public static string Types_IsOfType_Failed { get; } = "The param is not of expected type. Expected: '{0}'. Got: '{1}'.";
         public static string Types_IsNotOfType_Failed { get; } = "The param was expected to not be of the type: '{0}'. But it was.";
         public static string Types_IsAssignableToType_Failed { get; } = "The param is not assignable to the expected type. Expected: '{0}'. Got: '{1}'.";

--- a/src/tests/UnitTests/EnsureStringParamTests.cs
+++ b/src/tests/UnitTests/EnsureStringParamTests.cs
@@ -499,5 +499,50 @@ namespace UnitTests
                 () => EnsureArg.StartsWith(value, startPart, ParamName),
                 () => Ensure.That(value, ParamName).StartsWith(startPart));
         }
+
+        [Fact]
+        public void IsAllLettersOrDigits_WhenStringIsAllLettersAndDigits_It_should_not_throw()
+        {
+            const string value = "aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789";
+
+            ShouldNotThrow(
+                () => Ensure.String.IsAllLettersOrDigits(value, ParamName),
+                () => EnsureArg.IsAllLettersOrDigits(value, ParamName),
+                () => Ensure.That(value, ParamName).IsAllLettersOrDigits());
+        }
+
+        [Fact]
+        public void IsAllLettersOrDigits_WhenStringIsAllDigits_It_should_not_throw()
+        {
+            const string value = "0123456789";
+
+            ShouldNotThrow(
+                () => Ensure.String.IsAllLettersOrDigits(value, ParamName),
+                () => EnsureArg.IsAllLettersOrDigits(value, ParamName),
+                () => Ensure.That(value, ParamName).IsAllLettersOrDigits());
+        }
+
+        [Fact]
+        public void IsAllLettersOrDigits_WhenStringIsAllLetters_It_should_not_throw()
+        {
+            const string value = "aBcDeFgHiJkLmNoPqRsTuVwXyZ";
+
+            ShouldNotThrow(
+                () => Ensure.String.IsAllLettersOrDigits(value, ParamName),
+                () => EnsureArg.IsAllLettersOrDigits(value, ParamName),
+                () => Ensure.That(value, ParamName).IsAllLettersOrDigits());
+        }
+
+        [Fact]
+        public void IsAllLettersOrDigits_WhenStringDoesNotHaveLettersOrDigits_It_should_throw()
+        {
+            const string value = "<:)-+-<";
+
+            ShouldThrow<ArgumentException>(
+                string.Format(ExceptionMessages.Strings_IsAllLettersOrDigits_Failed, value),
+                () => Ensure.String.IsAllLettersOrDigits(value, ParamName),
+                () => EnsureArg.IsAllLettersOrDigits(value, ParamName),
+                () => Ensure.That(value, ParamName).IsAllLettersOrDigits());
+        }
     }
 }


### PR DESCRIPTION
Add the `IsAllLettersOrDigits` method according to [this comment](https://github.com/danielwertheim/Ensure.That/issues/141#issuecomment-633036292) in #141  

This method checks if all chars of a string is either a letter or a digit and raise an `ArgumentException` if not

I tried to be consistent with the existing code base, I can modify whatever I may have missed !