### PR TITLE
Fixes #147 SizeIs for Strings is now HasLength

### DIFF
--- a/src/projects/EnsureThat/Enforcers/StringArg.cs
+++ b/src/projects/EnsureThat/Enforcers/StringArg.cs
@@ -68,6 +68,21 @@ namespace EnsureThat.Enforcers
 
             return value;
         }
+        
+        [NotNull]
+        [ContractAnnotation("value:null => halt")]
+        public string HasLength([ValidatedNotNull]string value, int expected, [InvokerParameterName] string paramName = null, OptsFn optsFn = null)
+        {
+            Ensure.Any.IsNotNull(value, paramName, optsFn);
+
+            if (value.Length != expected)
+                throw Ensure.ExceptionFactory.ArgumentException(
+                    string.Format(ExceptionMessages.Strings_SizeIs_Failed, expected, value.Length),
+                    paramName,
+                    optsFn);
+
+            return value;
+        }
 
         [NotNull]
         [ContractAnnotation("value:null => halt")]
@@ -110,18 +125,9 @@ namespace EnsureThat.Enforcers
 
         [NotNull]
         [ContractAnnotation("value:null => halt")]
-        public string SizeIs([ValidatedNotNull]string value, int expected, [InvokerParameterName] string paramName = null, OptsFn optsFn = null)
-        {
-            Ensure.Any.IsNotNull(value, paramName, optsFn);
-
-            if (value.Length != expected)
-                throw Ensure.ExceptionFactory.ArgumentException(
-                    string.Format(ExceptionMessages.Strings_SizeIs_Failed, expected, value.Length),
-                    paramName,
-                    optsFn);
-
-            return value;
-        }
+        [Obsolete("Use 'HasLength' instead. This will be removed in an upcoming version.")]
+        public string SizeIs([ValidatedNotNull] string value, int expected, [InvokerParameterName] string paramName = null, OptsFn optsFn = null)
+            => HasLength(value, expected, paramName, optsFn);
 
         public string Is(string value, string expected, [InvokerParameterName] string paramName = null, OptsFn optsFn = null)
             => IsEqualTo(value, expected, paramName, optsFn);

--- a/src/projects/EnsureThat/EnsureArg.Strings.cs
+++ b/src/projects/EnsureThat/EnsureArg.Strings.cs
@@ -30,6 +30,11 @@ namespace EnsureThat
 
         [NotNull]
         [ContractAnnotation("value:null => halt")]
+        public static string HasLength([ValidatedNotNull] string value, int expected, [InvokerParameterName] string paramName = null, OptsFn optsFn = null)
+            => Ensure.String.HasLength(value, expected, paramName, optsFn);
+        
+        [NotNull]
+        [ContractAnnotation("value:null => halt")]
         public static string HasLengthBetween([ValidatedNotNull] string value, int minLength, int maxLength, [InvokerParameterName] string paramName = null, OptsFn optsFn = null)
             => Ensure.String.HasLengthBetween(value, minLength, maxLength, paramName, optsFn);
 
@@ -43,6 +48,7 @@ namespace EnsureThat
 
         [NotNull]
         [ContractAnnotation("value:null => halt")]
+        [Obsolete("Use 'HasLength' instead. This will be removed in an upcoming version.")]
         public static string SizeIs([ValidatedNotNull] string value, int expected, [InvokerParameterName] string paramName = null, OptsFn optsFn = null)
             => Ensure.String.SizeIs(value, expected, paramName, optsFn);
 

--- a/src/projects/EnsureThat/EnsureThatStringExtensions.cs
+++ b/src/projects/EnsureThat/EnsureThatStringExtensions.cs
@@ -20,6 +20,9 @@ namespace EnsureThat
 
         public static void IsNotEmpty(this in StringParam param)
             => Ensure.String.IsNotEmpty(param.Value, param.Name, param.OptsFn);
+        
+        public static void HasLength(this in StringParam param, int expected)
+            => Ensure.String.HasLength(param.Value, expected, param.Name, param.OptsFn);
 
         public static void HasLengthBetween(this in StringParam param, int minLength, int maxLength)
             => Ensure.String.HasLengthBetween(param.Value, minLength, maxLength, param.Name, param.OptsFn);
@@ -30,6 +33,7 @@ namespace EnsureThat
         public static void Matches(this in StringParam param, [NotNull] Regex match)
             => Ensure.String.Matches(param.Value, match, param.Name, param.OptsFn);
 
+        [Obsolete("Use 'HasLength' instead. This will be removed in an upcoming version.")]
         public static void SizeIs(this in StringParam param, int expected)
             => Ensure.String.SizeIs(param.Value, expected, param.Name, param.OptsFn);
 

--- a/src/tests/UnitTests/EnsureStringParamTests.cs
+++ b/src/tests/UnitTests/EnsureStringParamTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Text.RegularExpressions;
 using EnsureThat;
 using Xunit;
+#pragma warning disable 618
 
 namespace UnitTests
 {
@@ -175,6 +176,41 @@ namespace UnitTests
                 () => Ensure.String.IsNotEmpty(value, ParamName),
                 () => EnsureArg.IsNotEmpty(value, ParamName),
                 () => Ensure.That(value, ParamName).IsNotEmpty());
+        }
+        
+        [Fact]
+        public void HasLength_When_null_It_throws_ArgumentNullException()
+        {
+            string value = null;
+            var expected = 1;
+
+            AssertIsNotNull(
+                () => Ensure.String.HasLength(value, expected, ParamName),
+                () => EnsureArg.HasLength(value, expected, ParamName),
+                () => Ensure.That(value, ParamName).HasLength(expected));
+        }
+
+        [Fact]
+        public void HasLength_When_non_matching_length_of_string_It_throws_ArgumentException()
+        {
+            var value = "Some string";
+            var expected = value.Length + 1;
+
+            ShouldThrow<ArgumentException>(
+                string.Format(ExceptionMessages.Strings_SizeIs_Failed, expected, value.Length),
+                () => Ensure.String.HasLength(value, expected, ParamName),
+                () => EnsureArg.HasLength(value, expected, ParamName),
+                () => Ensure.That(value, ParamName).HasLength(expected));
+        }
+
+        [Fact]
+        public void HasLength_When_matching_constraint_It_should_not_throw()
+        {
+            var value = "Some string";
+
+            ShouldNotThrow(
+                () => Ensure.String.HasLength(value, value.Length, ParamName),
+                () => EnsureArg.HasLength(value, value.Length, ParamName));
         }
 
         [Fact]


### PR DESCRIPTION
Closes #147 

Have not touched the `SizeIs` members for collections, lists etc. This since these are collections of "things" using both `Lenght` and `Count` concepts. I then see `SizeIs` as a good enough middle way to collect those under. Yes one could argue that strings are an ordered sequence of chars and therefore should have `SizeIs` but in that case I do believe that the `Length` concept is more "correct" and aligns better with `HasLengthBetween`.